### PR TITLE
Add Jest tests for helper utilities

### DIFF
--- a/__tests__/helper.test.js
+++ b/__tests__/helper.test.js
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+import { getImageUrl, getFormattedDate, getFormattedTime } from '../src/utils/helper.js';
+
+describe('helper utilities', () => {
+  beforeEach(() => {
+    global.window = { location: { hostname: 'localhost' } };
+  });
+
+  describe('getImageUrl', () => {
+    test('returns default image when no path provided', () => {
+      expect(getImageUrl()).toBe('/img/placeholder.jpg');
+    });
+
+    test('returns absolute url unchanged', () => {
+      const url = 'https://example.com/img.png';
+      expect(getImageUrl(url)).toBe(url);
+    });
+
+    test('normalizes relative paths', () => {
+      const result = getImageUrl('images/pic.jpg');
+      expect(result).toBe('http://localhost:5000/images/pic.jpg');
+    });
+  });
+
+  describe('date formatting', () => {
+    const date = new Date('2024-06-01T12:34:56Z');
+    test('getFormattedDate returns uk-UA date string', () => {
+      expect(getFormattedDate(date)).toBe('1 червня 2024 р.');
+    });
+
+    test('getFormattedTime returns uk-UA time string', () => {
+      expect(getFormattedTime(date)).toBe('12:34');
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "preview": "next preview"
+    "preview": "next preview",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "next": "^15.3.2",
@@ -16,12 +17,16 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^22.15.29",
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",
     "eslint": "^8.0.0",
     "eslint-config-next": "latest",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3",
     "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- install Jest dependencies
- add Jest config
- add tests for helper functions
- add `npm test` script

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_683f7e330ee88323a95a0056ecb412dc