### PR TITLE
Add missing createRoot import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import 'leaflet/dist/leaflet.css'
 import React from 'react'
+import { createRoot } from 'react-dom/client'
 import './styles/index.scss'
 import App from '/src/assets/screens/home/Home.jsx'
 import '/src/i18n/config'


### PR DESCRIPTION
## Summary
- import `createRoot` from `react-dom/client` in `src/index.js`

## Testing
- `npm ci --silent`
- `npm run build` *(fails: numerous ESLint errors)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_683f7c0f2c54832384af939b78be107b