### PR TITLE
Fix API base url via env variable

### DIFF
--- a/__tests__/helper.test.js
+++ b/__tests__/helper.test.js
@@ -4,6 +4,7 @@ import { getImageUrl, getFormattedDate, getFormattedTime } from '../src/utils/he
 describe('helper utilities', () => {
   beforeEach(() => {
     global.window = { location: { hostname: 'localhost' } };
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:5000';
   });
 
   describe('getImageUrl', () => {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -5,9 +5,9 @@ const host = window.location.hostname
 const isLocalhost = host === 'localhost' || host === '127.0.0.1'
 // Create an instance of axios with default configurations
 const API = axios.create({
-	baseURL: isLocalhost
-		? 'http://localhost:5000/api/'
-		: 'https://art.playukraine.com/api/',
+        baseURL: isLocalhost
+                ? `${process.env.NEXT_PUBLIC_API_URL}/api/`
+                : 'https://art.playukraine.com/api/',
 	timeout: 10000, // Optional: set a timeout for requests
 	headers: {
 		'Content-Type': 'application/json',

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,9 +1,9 @@
 export function getBaseUrl() {
 	const host = window.location.hostname
 	const isLocalhost = host === 'localhost' || host === '127.0.0.1'
-	const baseUrl = isLocalhost
-		? 'http://localhost:5000'
-		: 'https://art.playukraine.com'
+       const baseUrl = isLocalhost
+               ? process.env.NEXT_PUBLIC_API_URL
+               : 'https://art.playukraine.com'
 	return baseUrl
 }
 


### PR DESCRIPTION
## Summary
- replace hardcoded localhost API URLs with env variable `NEXT_PUBLIC_API_URL`
- adjust helper tests to set the env variable
- create `.env.local` file locally (ignored) with default API URL

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f8b5ed5648323a943575896e9f0c2