### PR TITLE
Fix API utils for server-side usage

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,13 +1,17 @@
 // src/utils/api.js
 
 import axios from 'axios'
-const host = window.location.hostname
+// Determine the host in both browser and server environments
+const host =
+  typeof window !== 'undefined'
+    ? window.location.hostname
+    : process.env.NEXT_PUBLIC_HOST || 'localhost'
 const isLocalhost = host === 'localhost' || host === '127.0.0.1'
 // Create an instance of axios with default configurations
 const API = axios.create({
         baseURL: isLocalhost
-                ? `${process.env.NEXT_PUBLIC_API_URL}/api/`
-                : 'https://art.playukraine.com/api/',
+                ? `${(process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000')}/api/`
+                : process.env.NEXT_PUBLIC_PROD_API_URL || 'https://art.playukraine.com/api/',
 	timeout: 10000, // Optional: set a timeout for requests
 	headers: {
 		'Content-Type': 'application/json',
@@ -16,29 +20,36 @@ const API = axios.create({
 
 // Add a request interceptor to include the token in headers
 API.interceptors.request.use(
-	config => {
-		const token = localStorage.getItem('token') // Or use cookies
-		if (token) {
-			config.headers.Authorization = `Bearer ${token}`
-		}
-		return config
-	},
-	error => {
-		return Promise.reject(error)
-	}
+        config => {
+                let token
+                if (typeof window !== 'undefined') {
+                        token = localStorage.getItem('token')
+                } else {
+                        token = process.env.TOKEN
+                }
+                if (token) {
+                        config.headers.Authorization = `Bearer ${token}`
+                }
+                return config
+        },
+        error => {
+                return Promise.reject(error)
+        }
 )
 
 // Add a response interceptor to handle responses globally
 API.interceptors.response.use(
-	response => response,
-	error => {
-		// You can handle specific status codes here
-		if (error.response && error.response.status === 401) {
-			// Handle unauthorized access (e.g., redirect to login)
-			window.location.href = '/login'
-		}
-		return Promise.reject(error)
-	}
+        response => response,
+        error => {
+                // You can handle specific status codes here
+                if (error.response && error.response.status === 401) {
+                        // Handle unauthorized access (e.g., redirect to login)
+                        if (typeof window !== 'undefined') {
+                                window.location.href = '/login'
+                        }
+                }
+                return Promise.reject(error)
+        }
 )
 
 export default API


### PR DESCRIPTION
## Summary
- update `src/utils/api.js` to avoid referencing browser globals when not available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841a401ed2483238d1b2bf457a072f8