### PR TITLE
Remove extra logout export

### DIFF
--- a/src/Context/AuthContext.jsx
+++ b/src/Context/AuthContext.jsx
@@ -5,9 +5,6 @@ const AuthContext = createContext()
 
 export const useAuth = () => useContext(AuthContext)
 
-export const logout = () => {
-	localStorage.removeItem('token')
-}
 
 export const AuthProvider = ({ children }) => {
 	const [user, setUser] = useState(null)


### PR DESCRIPTION
## Summary
- remove redundant `logout` export from AuthContext

## Testing
- `npm test` *(fails: Cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad4a46948323941f658af95e1046