### PR TITLE
Add sitemap generation

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,30 @@
+/** @type {import('next-sitemap').IConfig} */
+const config = {
+  siteUrl: 'https://art.playukraine.com',
+  generateRobotsTxt: true,
+  generateIndexSitemap: false,
+  outDir: 'public',
+  output: "export",
+  transform: async (config, path) => ({
+    loc: path,
+    changefreq: path === '/' ? 'daily' : 'weekly',
+    priority: path === '/' ? 1.0 : 0.7,
+    lastmod: new Date().toISOString(),
+  }),
+  additionalPaths: async () => {
+    const { newsList } = await import('./src/data/news.js');
+    const paths = [
+      { loc: '/', changefreq: 'daily', priority: 1.0 },
+      { loc: '/news', changefreq: 'weekly', priority: 0.7 },
+      { loc: '/ssr', changefreq: 'weekly', priority: 0.7 },
+    ];
+    const newsPaths = newsList.map((n) => ({
+      loc: `/news/${n.id}`,
+      changefreq: 'weekly',
+      priority: 0.7,
+      lastmod: new Date().toISOString(),
+    }));
+    return [...paths.map((p) => ({ ...p, lastmod: new Date().toISOString() })), ...newsPaths];
+  },
+};
+export default config;

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
-module.exports = {
+const config = {
   i18n: {
     locales: ['uk', 'en'],
-    defaultLocale: 'uk'
-  }
-}
+    defaultLocale: 'uk',
+  },
+};
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
+        "next-sitemap": "^4.2.3",
         "typescript": "^5.8.3"
       }
     },
@@ -563,6 +564,13 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8362,6 +8370,41 @@
         "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
+      }
+    },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+      "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -9,14 +9,15 @@
     "start": "next start",
     "lint": "next lint",
     "preview": "next preview",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "sitemap": "next-sitemap"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.80.6",
     "next": "^15.3.2",
+    "next-intl": "^3.4.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "next-intl": "^3.4.2"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
@@ -29,6 +30,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
+    "next-sitemap": "^4.2.3",
     "typescript": "^5.8.3"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+# *
+User-agent: *
+Allow: /
+
+# Host
+Host: https://art.playukraine.com
+
+# Sitemaps
+Sitemap: https://art.playukraine.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://art.playukraine.com</loc><lastmod>2025-06-05T16:07:05.420Z</lastmod><changefreq>daily</changefreq><priority>1</priority></url>
+<url><loc>https://art.playukraine.com/news</loc><lastmod>2025-06-05T16:07:05.420Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://art.playukraine.com/ssr</loc><lastmod>2025-06-05T16:07:05.420Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://art.playukraine.com/news/1</loc><lastmod>2025-06-05T16:07:05.419Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://art.playukraine.com/news/2</loc><lastmod>2025-06-05T16:07:05.420Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+</urlset>


### PR DESCRIPTION
## Summary
- install `next-sitemap`
- configure `next-sitemap.config.js` for Art & Culture site
- add `sitemap` npm script
- generate `sitemap.xml` and `robots.txt`
- switch project configs to ESM to allow running `next-sitemap`

## Testing
- `npm test`
- `npm run sitemap`

------
https://chatgpt.com/codex/tasks/task_e_6841be9e8280832395bf8722c2fb3e77