### PR TITLE
Use dynamic import for MainPage banner slider

### DIFF
--- a/src/assets/screens/mainPage/MainPage.jsx
+++ b/src/assets/screens/mainPage/MainPage.jsx
@@ -7,9 +7,18 @@ import MainArtists from '@components/Blocks/MainArtists.jsx'
 import MainExhibitions from '@components/Blocks/MainExhibitions.jsx'
 import MainMuseums from '@components/Blocks/MainMuseums.jsx'
 import MainNews from '@components/Blocks/MainNews.jsx'
-import MainPageBannerSlider from '@components/Sliders/MainPageBannerSlider/MainPageBannerSlider.jsx'
+import dynamic from 'next/dynamic'
+import Loading from '@components/Blocks/Loading.jsx'
 import MainInstagramSlider from '@components/Sliders/MainInstagramSlider/MainInstagramSlider.jsx'
 import MainPopularArtsSlider from '@components/Sliders/MainPopularArtsSlider/MainPopularArtsSlider.jsx'
+
+const MainPageBannerSlider = dynamic(
+  () => import('@components/Sliders/MainPageBannerSlider/MainPageBannerSlider.jsx'),
+  {
+    loading: () => <Loading />,
+    ssr: false,
+  },
+)
 function MainPage() {
 	const { t } = useTranslation()
 	const [isExpanded, setIsExpanded] = useState(false)


### PR DESCRIPTION
## Summary
- load `MainPageBannerSlider` via `next/dynamic`
- show a loading indicator while the slider code loads

## Testing
- `npm test`
- `npm run lint` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6841be9cb5648323a7005dd82791a4ea