### PR TITLE
Add revalidate for news page

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ SEO metadata is defined in [`src/meta/index.js`](src/meta/index.js).
 A simple middleware is defined in [`middleware.ts`](middleware.ts). It adds an `X-Art-Culture` header to all responses.
 
 A demo SSR page is available at [`src/pages/ssr.js`](src/pages/ssr.js) which uses `getServerSideProps` to select a random news item on each request.
+
+## Static Regeneration
+
+News pages are pre-rendered at build time but regenerate periodically. The
+`revalidate` export in [`src/app/news/[id]/page.tsx`](src/app/news/%5Bid%5D/page.tsx)
+instructs Next.js to refresh the static content every 60 seconds.

--- a/src/app/news/[id]/page.tsx
+++ b/src/app/news/[id]/page.tsx
@@ -3,6 +3,9 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { newsList, NewsItem } from '@/data/news'
 
+// Incremental static regeneration
+export const revalidate = 60
+
 interface Props {
   params: { id: string }
 }


### PR DESCRIPTION
## Summary
- regenerate static news pages by exporting `revalidate`
- explain static regeneration in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841be9b9c348323a98ffb90317b93ee