### PR TITLE
Add news API route and fetch data via API

### DIFF
--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+import { newsList } from '@/data/news'
+
+export async function GET() {
+  return NextResponse.json(newsList)
+}

--- a/src/app/news/[id]/page.tsx
+++ b/src/app/news/[id]/page.tsx
@@ -1,17 +1,21 @@
 // src/app/news/[id]/page.tsx
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { newsList, NewsItem } from '@/data/news'
+import { NewsItem } from '@/data/news'
 
 interface Props {
   params: { id: string }
 }
 
 export async function generateStaticParams() {
+  const res = await fetch('http://localhost:3000/api/news')
+  const newsList: NewsItem[] = await res.json()
   return newsList.map((n) => ({ id: n.id }))
 }
 
 export async function generateMetadata({ params }: Props) {
+  const res = await fetch('http://localhost:3000/api/news')
+  const newsList: NewsItem[] = await res.json()
   const news = newsList.find((n) => n.id === params.id)
   if (!news) return {}
   return {
@@ -29,6 +33,8 @@ export async function generateMetadata({ params }: Props) {
 }
 
 export default async function NewsPage({ params }: Props) {
+  const res = await fetch('http://localhost:3000/api/news')
+  const newsList: NewsItem[] = await res.json()
   const news = newsList.find((n) => n.id === params.id) as NewsItem
   if (!news) notFound()
 

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,7 +1,10 @@
 import Link from 'next/link'
-import { newsList } from '@/data/news'
+import { NewsItem } from '@/data/news'
 
-export default function NewsIndex() {
+export default async function NewsIndex() {
+  const res = await fetch('http://localhost:3000/api/news')
+  const newsList: NewsItem[] = await res.json()
+
   return (
     <main className="max-w-3xl mx-auto p-4">
       <h1 className="text-3xl font-bold mb-6">Всі новини</h1>


### PR DESCRIPTION
## Summary
- add `/api/news` route returning `newsList` as JSON
- refactor news pages to fetch data from the new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c70fbc708323832627132d526211