### PR TITLE
Implement locale routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ SEO metadata is defined in [`src/meta/index.js`](src/meta/index.js).
 
 ## Middleware and SSR
 
-A simple middleware is defined in [`middleware.ts`](middleware.ts). It adds an `X-Art-Culture` header to all responses.
+The middleware in [`middleware.ts`](middleware.ts) now detects the locale from the
+URL. Requests without a locale prefix are redirected to `/uk` by default and an
+`X-Art-Culture` header is added to all responses.
 
 A demo SSR page is available at [`src/pages/ssr.js`](src/pages/ssr.js) which uses `getServerSideProps` to select a random news item on each request.
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,34 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+const locales = ['uk', 'en']
+const PUBLIC_FILE = /\.(.*)$/
+
 export function middleware(request: NextRequest) {
-  const response = NextResponse.next()
-  response.headers.set('X-Art-Culture', 'true')
-  return response
+  const { pathname } = request.nextUrl
+
+  if (
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/api') ||
+    PUBLIC_FILE.test(pathname)
+  ) {
+    const res = NextResponse.next()
+    res.headers.set('X-Art-Culture', 'true')
+    return res
+  }
+
+  const locale = pathname.split('/')[1]
+
+  if (!locales.includes(locale)) {
+    const url = request.nextUrl.clone()
+    url.pathname = pathname === '/' ? `/${locales[0]}` : `/${locales[0]}${pathname}`
+    return NextResponse.redirect(url)
+  }
+
+  const res = NextResponse.next()
+  res.headers.set('X-Art-Culture', 'true')
+  res.headers.set('x-locale', locale)
+  return res
 }
 
 export const config = {

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,2 @@
-const config = {
-  i18n: {
-    locales: ['uk', 'en'],
-    defaultLocale: 'uk',
-  },
-};
+const config = {};
 export default config;

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,1 @@
+export { default } from '../error'

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react'
+import Script from 'next/script'
+import localFont from 'next/font/local'
+
+const firaSans = localFont({
+  src: [
+    { path: '../customFonts/FiraSans-Regular.ttf', weight: '400', style: 'normal' },
+    { path: '../customFonts/FiraSans-Bold.ttf', weight: '700', style: 'normal' },
+  ],
+  display: 'swap',
+})
+
+export const metadata = {
+  title: 'Art Play Ukraine',
+  description: 'Культура, мистецтво та новини від Art Play Ukraine',
+}
+
+interface LocaleLayoutProps {
+  children: ReactNode
+  params: { locale: string }
+}
+
+export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
+  const gaId = process.env.NEXT_PUBLIC_GA_ID
+  const isProd = process.env.NODE_ENV === 'production'
+
+  return (
+    <html lang={params.locale}>
+      <body className={firaSans.className}>
+        {isProd && gaId && (
+          <>
+            <Script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} strategy="afterInteractive" />
+            <Script id="ga-init" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${gaId}');
+              `}
+            </Script>
+          </>
+        )}
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/src/app/[locale]/news/[id]/page.tsx
+++ b/src/app/[locale]/news/[id]/page.tsx
@@ -1,0 +1,1 @@
+export { default, generateMetadata, generateStaticParams, revalidate } from '../../../news/[id]/page'

--- a/src/app/[locale]/news/page.tsx
+++ b/src/app/[locale]/news/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../news/page'

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,1 @@
+export { default } from '../not-found'

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,0 +1,2 @@
+export { metadata } from '../page'
+export { default } from '../page'


### PR DESCRIPTION
## Summary
- add locale-aware middleware and remove i18n block from config
- expose new dynamic `[locale]` pages that reuse existing content
- update documentation for locale handling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a25e79a0832390eb42c30046be7f