### PR TITLE
Add react-refresh eslint plugin

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
-  settings: { react: { version: '18.2' } },
+  settings: { react: { version: 'detect' } },
   plugins: ['react-refresh'],
   rules: {
     'react/jsx-no-target-blank': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/react-dom": "^19.1.6",
         "eslint": "^8.46.0",
         "eslint-config-next": "^15.3.2",
+        "eslint-plugin-react-refresh": "^0.4.20",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
         "next-sitemap": "^4.2.3",
@@ -5543,6 +5544,16 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.20.tgz",
+      "integrity": "sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "next-sitemap": "^4.2.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "eslint-plugin-react-refresh": "^0.4.20"
   }
 }


### PR DESCRIPTION
## Summary
- install `eslint-plugin-react-refresh`
- set eslint `react` version to auto-detect

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842a6eb3d548323bb7c3280a44e8740