### PR TITLE
Use env base URL for news pages

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 # Example environment variables for Art & Culture
+# Base URL used by fetch() in server components
 NEXT_PUBLIC_API_URL=http://localhost:5000
 REACT_APP_API_URL=http://localhost:5000
 # For production you might use the following:

--- a/src/app/news/[id]/page.tsx
+++ b/src/app/news/[id]/page.tsx
@@ -11,13 +11,15 @@ interface Props {
 }
 
 export async function generateStaticParams() {
-  const res = await fetch('http://localhost:3000/api/news')
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+  const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
   return newsList.map((n) => ({ id: n.id }))
 }
 
 export async function generateMetadata({ params }: Props) {
-  const res = await fetch('http://localhost:3000/api/news')
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+  const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
   const news = newsList.find((n) => n.id === params.id)
   if (!news) return {}
@@ -36,7 +38,8 @@ export async function generateMetadata({ params }: Props) {
 }
 
 export default async function NewsPage({ params }: Props) {
-  const res = await fetch('http://localhost:3000/api/news')
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+  const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
   const news = newsList.find((n) => n.id === params.id) as NewsItem
   if (!news) notFound()

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -2,7 +2,8 @@ import Link from 'next/link'
 import { NewsItem } from '@/data/news'
 
 export default async function NewsIndex() {
-  const res = await fetch('http://localhost:3000/api/news')
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+  const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
 
   return (


### PR DESCRIPTION
## Summary
- fetch news API using the `NEXT_PUBLIC_API_URL` base URL
- document the env variable in `.env.sample`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842ad1e34fc8323bb6465d493e90b77