### PR TITLE
Fix SSR window access

### DIFF
--- a/src/assets/components/Blocks/MainArtists.jsx
+++ b/src/assets/components/Blocks/MainArtists.jsx
@@ -14,9 +14,13 @@ function MainArtists() {
 	const [regDate, setRegDate] = useState('')
 	const [regTime, setRegTime] = useState('')
 	const { user } = useAuth()
-	const [visibleCreatorsCount, setVisibleCreatorsCount] = useState(
-		getPostsCount(window.innerWidth),
-	)
+        const [visibleCreatorsCount, setVisibleCreatorsCount] = useState(
+                getPostsCount(
+                        typeof window !== 'undefined'
+                                ? window.innerWidth
+                                : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024'),
+                ),
+        )
 
 	function getPostsCount(width) {
 		if (width === null || width === undefined) {
@@ -36,27 +40,39 @@ function MainArtists() {
 		}
 	}
 
-	useEffect(() => {
-		const handleResize = () => {
-			const newPostCount = getPostsCount(window.innerWidth)
-			console.log(
-				`Window width: ${window.innerWidth}, New post count: ${newPostCount}`,
-			)
-			if (newPostCount !== visibleCreatorsCount) {
-				setVisibleCreatorsCount(newPostCount)
-				console.log(`Updated visiblePostsCount to: ${newPostCount}`)
-			}
-		}
+        useEffect(() => {
+                const handleResize = () => {
+                        const width =
+                                typeof window !== 'undefined'
+                                        ? window.innerWidth
+                                        : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024')
+                        const newPostCount = getPostsCount(width)
+                        if (typeof window !== 'undefined') {
+                                console.log(
+                                        `Window width: ${window.innerWidth}, New post count: ${newPostCount}`,
+                                )
+                        }
+                        if (newPostCount !== visibleCreatorsCount) {
+                                setVisibleCreatorsCount(newPostCount)
+                                if (typeof window !== 'undefined') {
+                                        console.log(`Updated visiblePostsCount to: ${newPostCount}`)
+                                }
+                        }
+                }
 
-		window.addEventListener('resize', handleResize)
+                if (typeof window !== 'undefined') {
+                        window.addEventListener('resize', handleResize)
+                }
 
-		// Initial check
-		handleResize()
+                // Initial check
+                handleResize()
 
-		return () => {
-			window.removeEventListener('resize', handleResize)
-		}
-	}, [visibleCreatorsCount])
+                return () => {
+                        if (typeof window !== 'undefined') {
+                                window.removeEventListener('resize', handleResize)
+                        }
+                }
+        }, [visibleCreatorsCount])
 
 	useEffect(() => {
 		axios

--- a/src/assets/components/Blocks/MainExhibitions.jsx
+++ b/src/assets/components/Blocks/MainExhibitions.jsx
@@ -10,9 +10,13 @@ function MainExhibitions() {
 	const { t } = useTranslation()
 	const [exhibitions, setExhibitions] = useState([])
 	const navigate = useNavigate()
-	const [visibleExhibitionsCount, setVisibleExhibitionsCount] = useState(
-		getPostsCount(window.innerWidth),
-	)
+        const [visibleExhibitionsCount, setVisibleExhibitionsCount] = useState(
+                getPostsCount(
+                        typeof window !== 'undefined'
+                                ? window.innerWidth
+                                : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024'),
+                ),
+        )
 
 	function getPostsCount(width) {
 		if (width === null || width === undefined) {
@@ -32,26 +36,36 @@ function MainExhibitions() {
 		}
 	}
 
-	useEffect(() => {
-		const handleResize = () => {
-			const newPostCount = getPostsCount(window.innerWidth)
-			if (newPostCount !== visibleExhibitionsCount) {
-				setVisibleExhibitionsCount(newPostCount)
-				console.log(
-					`Window width: ${window.innerWidth}, Visible posts count: ${newPostCount}`,
-				)
-			}
-		}
+        useEffect(() => {
+                const handleResize = () => {
+                        const width =
+                                typeof window !== 'undefined'
+                                        ? window.innerWidth
+                                        : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024')
+                        const newPostCount = getPostsCount(width)
+                        if (newPostCount !== visibleExhibitionsCount) {
+                                setVisibleExhibitionsCount(newPostCount)
+                                if (typeof window !== 'undefined') {
+                                        console.log(
+                                                `Window width: ${window.innerWidth}, Visible posts count: ${newPostCount}`,
+                                        )
+                                }
+                        }
+                }
 
-		window.addEventListener('resize', handleResize)
+                if (typeof window !== 'undefined') {
+                        window.addEventListener('resize', handleResize)
+                }
 
-		// Initial check
-		handleResize()
+                // Initial check
+                handleResize()
 
-		return () => {
-			window.removeEventListener('resize', handleResize)
-		}
-	}, [visibleExhibitionsCount])
+                return () => {
+                        if (typeof window !== 'undefined') {
+                                window.removeEventListener('resize', handleResize)
+                        }
+                }
+        }, [visibleExhibitionsCount])
 
 	useEffect(() => {
 		// Запит на отримання виставок з медіа-даними

--- a/src/assets/components/Blocks/MainMuseums.jsx
+++ b/src/assets/components/Blocks/MainMuseums.jsx
@@ -14,9 +14,13 @@ function MainMuseums() {
 	const { t } = useTranslation()
 	const [museums, setMuseums] = useState([])
 	const navigate = useNavigate()
-	const [visibleMuseumsCount, setVisibleMuseumsCount] = useState(
-		getPostsCount(window.innerWidth),
-	)
+        const [visibleMuseumsCount, setVisibleMuseumsCount] = useState(
+                getPostsCount(
+                        typeof window !== 'undefined'
+                                ? window.innerWidth
+                                : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024'),
+                ),
+        )
 
 	function getPostsCount(width) {
 		if (width === null || width === undefined) {
@@ -36,26 +40,36 @@ function MainMuseums() {
 		}
 	}
 
-	useEffect(() => {
-		const handleResize = () => {
-			const newPostCount = getPostsCount(window.innerWidth)
-			if (newPostCount !== visibleMuseumsCount) {
-				setVisibleMuseumsCount(newPostCount)
-				console.log(
-					`Window width: ${window.innerWidth}, Visible posts count: ${newPostCount}`,
-				)
-			}
-		}
+        useEffect(() => {
+                const handleResize = () => {
+                        const width =
+                                typeof window !== 'undefined'
+                                        ? window.innerWidth
+                                        : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024')
+                        const newPostCount = getPostsCount(width)
+                        if (newPostCount !== visibleMuseumsCount) {
+                                setVisibleMuseumsCount(newPostCount)
+                                if (typeof window !== 'undefined') {
+                                        console.log(
+                                                `Window width: ${window.innerWidth}, Visible posts count: ${newPostCount}`,
+                                        )
+                                }
+                        }
+                }
 
-		window.addEventListener('resize', handleResize)
+                if (typeof window !== 'undefined') {
+                        window.addEventListener('resize', handleResize)
+                }
 
-		// Initial check
-		handleResize()
+                // Initial check
+                handleResize()
 
-		return () => {
-			window.removeEventListener('resize', handleResize)
-		}
-	}, [visibleMuseumsCount])
+                return () => {
+                        if (typeof window !== 'undefined') {
+                                window.removeEventListener('resize', handleResize)
+                        }
+                }
+        }, [visibleMuseumsCount])
 
 	useEffect(() => {
 		// Запит на отримання постів з медіа-даними

--- a/src/assets/components/Blocks/MainNews.jsx
+++ b/src/assets/components/Blocks/MainNews.jsx
@@ -14,9 +14,13 @@ function MainNews() {
 	const { t } = useTranslation()
 	const [posts, setPosts] = useState([])
 
-	const [visiblePostsCount, setVisiblePostsCount] = useState(
-		getPostsCount(window.innerWidth),
-	)
+        const [visiblePostsCount, setVisiblePostsCount] = useState(
+                getPostsCount(
+                        typeof window !== 'undefined'
+                                ? window.innerWidth
+                                : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024'),
+                ),
+        )
 	const navigate = useNavigate()
 	const handleNewsPageClick = () => {
 		navigate('/news-page')
@@ -40,26 +44,36 @@ function MainNews() {
 		}
 	}
 
-	useEffect(() => {
-		const handleResize = () => {
-			const newPostCount = getPostsCount(window.innerWidth)
-			if (newPostCount !== visiblePostsCount) {
-				setVisiblePostsCount(newPostCount)
-				console.log(
-					`Window width: ${window.innerWidth}, Visible posts count: ${newPostCount}`,
-				)
-			}
-		}
+        useEffect(() => {
+                const handleResize = () => {
+                        const width =
+                                typeof window !== 'undefined'
+                                        ? window.innerWidth
+                                        : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024')
+                        const newPostCount = getPostsCount(width)
+                        if (newPostCount !== visiblePostsCount) {
+                                setVisiblePostsCount(newPostCount)
+                                if (typeof window !== 'undefined') {
+                                        console.log(
+                                                `Window width: ${window.innerWidth}, Visible posts count: ${newPostCount}`,
+                                        )
+                                }
+                        }
+                }
 
-		window.addEventListener('resize', handleResize)
+                if (typeof window !== 'undefined') {
+                        window.addEventListener('resize', handleResize)
+                }
 
-		// Initial check
-		handleResize()
+                // Initial check
+                handleResize()
 
-		return () => {
-			window.removeEventListener('resize', handleResize)
-		}
-	}, [visiblePostsCount])
+                return () => {
+                        if (typeof window !== 'undefined') {
+                                window.removeEventListener('resize', handleResize)
+                        }
+                }
+        }, [visiblePostsCount])
 
 	useEffect(() => {
 		// Запит на отримання постів з медіа-даними

--- a/src/assets/screens/newsPage/NewsPage.jsx
+++ b/src/assets/screens/newsPage/NewsPage.jsx
@@ -150,9 +150,13 @@ function NewsPage() {
 	const [error, setError] = useState(null)
 
 	// Determine the number of visible posts based on window width
-	const [visiblePostsCount, setVisiblePostsCount] = useState(
-		getPostsCount(window.innerWidth),
-	)
+        const [visiblePostsCount, setVisiblePostsCount] = useState(
+                getPostsCount(
+                        typeof window !== 'undefined'
+                                ? window.innerWidth
+                                : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024'),
+                ),
+        )
 	const [maxPostsCount, setMaxPostsCount] = useState(0)
 
 	function getPostsCount(width) {
@@ -170,23 +174,31 @@ function NewsPage() {
 	}
 
 	// Handle window resize to adjust visible posts count
-	useEffect(() => {
-		const handleResize = () => {
-			const newPostCount = getPostsCount(window.innerWidth)
-			if (newPostCount !== visiblePostsCount) {
-				setVisiblePostsCount(newPostCount)
-			}
-		}
+        useEffect(() => {
+                const handleResize = () => {
+                        const width =
+                                typeof window !== 'undefined'
+                                        ? window.innerWidth
+                                        : parseInt(process.env.NEXT_PUBLIC_DEFAULT_WIDTH || '1024')
+                        const newPostCount = getPostsCount(width)
+                        if (newPostCount !== visiblePostsCount) {
+                                setVisiblePostsCount(newPostCount)
+                        }
+                }
 
-		window.addEventListener('resize', handleResize)
+                if (typeof window !== 'undefined') {
+                        window.addEventListener('resize', handleResize)
+                }
 
-		// Initial check
-		handleResize()
+                // Initial check
+                handleResize()
 
-		return () => {
-			window.removeEventListener('resize', handleResize)
-		}
-	}, [visiblePostsCount, posts])
+                return () => {
+                        if (typeof window !== 'undefined') {
+                                window.removeEventListener('resize', handleResize)
+                        }
+                }
+        }, [visiblePostsCount, posts])
 	useEffect(() => {
 		const handleResize = () => {
 			const newMaxPostsCount = Math.min(posts.length, Math.max(maxPostsCount, visiblePostsCount * 2))

--- a/src/utils/ScrollToTop.jsx
+++ b/src/utils/ScrollToTop.jsx
@@ -3,9 +3,11 @@ import { useLocation } from 'react-router-dom'
 
 const ScrollToTop = () => {
 	const { pathname } = useLocation()
-	useEffect(() => {
-		window.scrollTo({ top: 0, behavior: 'smooth' })
-	}, [pathname])
+        useEffect(() => {
+                if (typeof window !== 'undefined') {
+                        window.scrollTo({ top: 0, behavior: 'smooth' })
+                }
+        }, [pathname])
 	return null
 }
 

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,10 +1,13 @@
 export function getBaseUrl() {
-	const host = window.location.hostname
-	const isLocalhost = host === 'localhost' || host === '127.0.0.1'
-       const baseUrl = isLocalhost
-               ? process.env.NEXT_PUBLIC_API_URL
-               : 'https://art.playukraine.com'
-	return baseUrl
+        const host =
+                typeof window !== 'undefined'
+                        ? window.location.hostname
+                        : process.env.NEXT_PUBLIC_HOST || 'localhost'
+        const isLocalhost = host === 'localhost' || host === '127.0.0.1'
+        const baseUrl = isLocalhost
+                ? process.env.NEXT_PUBLIC_API_URL
+                : 'https://art.playukraine.com'
+        return baseUrl
 }
 
 /**


### PR DESCRIPTION
## Summary
- guard `window` usage across utils and components
- use env-based fallbacks when running server-side

## Testing
- `npm install` *(fails: ERESOLVE)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ae355cc88323b5daa3909a8eb68a