### PR TITLE
Add Dockerfile for Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /usr/src/app
+COPY package.json package-lock.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+CMD ["npm","start"]


### PR DESCRIPTION
## Summary
- add Dockerfile to allow containerization for deployment (e.g. Cloud Run)

## Testing
- `npm install --legacy-peer-deps` *(fails: integrity checksum failed)*

------
https://chatgpt.com/codex/tasks/task_e_684342338d38832388fce7f19fc80a0b