### PR TITLE
Add React import in LazyImage

### DIFF
--- a/src/utils/LazyImage.jsx
+++ b/src/utils/LazyImage.jsx
@@ -1,4 +1,5 @@
 // src/components/LazyImage.jsx
+import React from 'react'
 import { useEffect, useRef, useState } from 'react'
 
 function LazyImage({ src, alt, className, onClick }) {


### PR DESCRIPTION
## Summary
- include React import in `LazyImage.jsx` to allow memo export

## Testing
- `npx jest --runInBand` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436c41d1ac8323b93ab2907d5e3b69