### PR TITLE
Add basic NextAuth configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,3 +20,8 @@ REDIS_URL=redis://localhost:6379
 # Shopify credentials
 SHOPIFY_API_KEY=
 SHOPIFY_API_SECRET=
+
+# NextAuth configuration
+NEXTAUTH_SECRET=
+GITHUB_ID=
+GITHUB_SECRET=

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Copy `.env.sample` to `.env` and update the values as needed.
 - `DATABASE_URL` – connection string for PostgreSQL
 - `REDIS_URL` or `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN`
 - `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET`
+- `NEXTAUTH_SECRET` and provider credentials like `GITHUB_ID`/`GITHUB_SECRET`
+
+## NextAuth
+
+Ensure the environment variables above are set. Start the development server and open `/api/auth/signin` to test authentication.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-router-dom": "^7.6.2",
     "react-toastify": "^11.0.5",
     "sass": "^1.89.1",
-    "swiper": "^11.2.8"
+    "swiper": "^11.2.8",
+    "next-auth": "^4.24.11"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,17 @@
+import NextAuth from 'next-auth'
+import GitHubProvider from 'next-auth/providers/github'
+import type { NextAuthOptions } from 'next-auth'
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID ?? '',
+      clientSecret: process.env.GITHUB_SECRET ?? '',
+    }),
+  ],
+  secret: process.env.NEXTAUTH_SECRET,
+}
+
+const handler = NextAuth(authOptions)
+
+export { handler as GET, handler as POST }


### PR DESCRIPTION
## Summary
- add `next-auth` dependency
- create `src/app/api/auth/[...nextauth]/route.ts`
- document `NEXTAUTH` variables in `.env.sample`
- update README with NextAuth instructions

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest --runInBand` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436c4767448323a9fcb33567199d52