### PR TITLE
Replace <img> tags with Next.js Image

### DIFF
--- a/src/assets/components/Sliders/ArtistPageSliders/ArtistPageMasonryGallery.jsx
+++ b/src/assets/components/Sliders/ArtistPageSliders/ArtistPageMasonryGallery.jsx
@@ -3,6 +3,7 @@
 import style from '@styles/components/Sliders/MasonrySlider/PageMasonryGallery.module.scss'
 import { debounce } from 'lodash' // Using lodash's debounce
 import PropTypes from 'prop-types'
+import Image from 'next/image'
 import {
 	useCallback,
 	useEffect,
@@ -599,22 +600,22 @@ const ArtistPageMasonryGallery = ({ products, baseUrl, creator, product }) => {
 											handleProductClick(img.productId)
 										}
 									>
-										<img
-											src={img.src}
-											alt=""
-											loading="lazy"
-											className={style.galleryImage}
-											style={{
-												width: '100%',
-												height: '100%', // Let height adjust based on image aspect ratio
-												objectFit: 'cover', // Ensures the image covers the container without distortion
-											}}
-											onError={(e) => {
-												e.target.onerror = null
-												e.target.src =
-													'/Img/newsCardERROR.jpg'
-												console.error(
-													'Error loading gallery image:',
+                                                                              <Image
+                                                                              src={img.src}
+                                                                              alt=""
+                                                                              width={250}
+                                                                              height={250}
+                                                                              loading="lazy"
+                                                                              className={style.galleryImage}
+                                                                              style={{
+                                                                              objectFit: 'cover', // Ensures the image covers the container without distortion
+                                                                              }}
+                                                                              onError={(e) => {
+                                                                              e.target.onerror = null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
+                                                                              console.error(
+                                                                              'Error loading gallery image:',
 													e.target.src,
 												)
 											}}
@@ -663,22 +664,22 @@ const ArtistPageMasonryGallery = ({ products, baseUrl, creator, product }) => {
 											handleProductClick(img.productId)
 										}
 									>
-										<img
-											src={img.src}
-											alt=""
-											loading="lazy"
-											className={style.galleryImage}
-											style={{
-												width: '100%',
-												height: '100%',
-												objectFit: 'cover',
-											}}
-											onError={(e) => {
-												e.target.onerror = null
-												e.target.src =
-													'/Img/newsCardERROR.jpg'
-												console.error(
-													'Error loading gallery image:',
+                                                                              <Image
+                                                                              src={img.src}
+                                                                              alt=""
+                                                                              width={250}
+                                                                              height={250}
+                                                                              loading="lazy"
+                                                                              className={style.galleryImage}
+                                                                              style={{
+                                                                              objectFit: 'cover',
+                                                                              }}
+                                                                              onError={(e) => {
+                                                                              e.target.onerror = null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
+                                                                              console.error(
+                                                                              'Error loading gallery image:',
 													e.target.src,
 												)
 											}}
@@ -727,22 +728,22 @@ const ArtistPageMasonryGallery = ({ products, baseUrl, creator, product }) => {
 											handleProductClick(img.productId)
 										}
 									>
-										<img
-											src={img.src}
-											alt=""
-											loading="lazy"
-											className={style.galleryImage}
-											style={{
-												width: '100%',
-												height: '100%',
-												objectFit: 'cover',
-											}}
-											onError={(e) => {
-												e.target.onerror = null
-												e.target.src =
-													'/Img/newsCardERROR.jpg'
-												console.error(
-													'Error loading gallery image:',
+                                                                              <Image
+                                                                              src={img.src}
+                                                                              alt=""
+                                                                              width={250}
+                                                                              height={250}
+                                                                              loading="lazy"
+                                                                              className={style.galleryImage}
+                                                                              style={{
+                                                                              objectFit: 'cover',
+                                                                              }}
+                                                                              onError={(e) => {
+                                                                              e.target.onerror = null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
+                                                                              console.error(
+                                                                              'Error loading gallery image:',
 													e.target.src,
 												)
 											}}
@@ -970,23 +971,21 @@ const ArtistPageMasonryGallery = ({ products, baseUrl, creator, product }) => {
 																'inline-block',
 														}}
 													>
-														<img
-															src={`${baseUrl}${image.imageUrl.replace('../../', '/')}`}
-															alt={`Product Image ${index + 1}`}
-															loading="lazy"
-															className={
-																style.modalImage
-															}
-															style={{
-																width: '100%',
-																height: 'auto',
-															}}
-															onError={(e) => {
-																e.target.onerror =
-																	null
-																e.target.src =
-																	'/Img/newsCardERROR.jpg'
-																console.error(
+                                                                              <Image
+                                                                              src={`${baseUrl}${image.imageUrl.replace('../../', '/')}`}
+                                                                              alt={`Product Image ${index + 1}`}
+                                                                              width={500}
+                                                                              height={320}
+                                                                              loading="lazy"
+                                                                              className={
+                                                                              style.modalImage
+                                                                              }
+                                                                              onError={(e) => {
+                                                                              e.target.onerror =
+                                                                              null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
+                                                                              console.error(
 																	'Error loading modal image:',
 																	e.target
 																		.src,
@@ -1121,16 +1120,18 @@ const ArtistPageMasonryGallery = ({ products, baseUrl, creator, product }) => {
 						{t('Всі роботи Митця')}
 					</p>
 
-					<img
-						className={`${style.buttonArrow}`}
-						src={'/Img/buttonArrow.svg'}
-						alt={t('Фото митця')}
-						loading="lazy"
-						onError={(e) => {
-							e.target.onerror = null
-							e.target.src = '/Img/newsCardERROR.jpg'
-						}}
-					/>
+                                        <Image
+                                                className={`${style.buttonArrow}`}
+                                                src={'/Img/buttonArrow.svg'}
+                                                alt={t('Фото митця')}
+                                                width={20}
+                                                height={20}
+                                                loading="lazy"
+                                                onError={(e) => {
+                                                        e.target.onerror = null
+                                                        e.target.src = '/Img/newsCardERROR.jpg'
+                                                }}
+                                        />
 				</button>
 			</div>
 		</div>

--- a/src/assets/components/Sliders/ArtistPageSliders/ArtistPageNewsArtistsSlider.jsx
+++ b/src/assets/components/Sliders/ArtistPageSliders/ArtistPageNewsArtistsSlider.jsx
@@ -15,6 +15,7 @@ import '@styles/components/Sliders/Base/NewsSlider.scss'
 import { useNavigate } from 'react-router-dom'
 import { getBaseUrl } from '../../../../utils/helper'
 import TranslatedContent from '../../Blocks/TranslatedContent'
+import Image from 'next/image'
 
 const Slide = ({ post, baseUrl }) => {
 	const { t } = useTranslation()
@@ -28,17 +29,19 @@ const Slide = ({ post, baseUrl }) => {
 	}
 	return (
 		<div className="NewsSliderCardContainer">
-			<div className="NewsSliderCardImgWrapper">
-				<img
-					className="NewsSliderCardImg"
-					src={featuredMediaUrl}
-					alt={t('Світлина мистецтва')}
-					onClick={() => handlePostClick(post.id)}
-					onError={(e) => {
-						e.target.onerror = null
-						e.target.src = '/Img/newsCardERROR.jpg'
-					}}
-				/>
+                        <div className="NewsSliderCardImgWrapper">
+                                <Image
+                                        className="NewsSliderCardImg"
+                                        src={featuredMediaUrl}
+                                        alt={t('Світлина мистецтва')}
+                                        width={282}
+                                        height={282}
+                                        onClick={() => handlePostClick(post.id)}
+                                        onError={(e) => {
+                                                e.target.onerror = null
+                                                e.target.src = '/Img/newsCardERROR.jpg'
+                                        }}
+                                />
 			</div>
 
 			<div className="NewsSliderCardTitleWrapper">

--- a/src/assets/components/Sliders/ArtistPageSliders/PopularOfThisArtistSlider.jsx
+++ b/src/assets/components/Sliders/ArtistPageSliders/PopularOfThisArtistSlider.jsx
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types'
 import { useNavigate } from 'react-router-dom'
 import { Navigation, Pagination } from 'swiper/modules'
 import '/src/styles/components/Sliders/ArtistPageSliders/PopularOfThisArtistSlider.scss'
+import Image from 'next/image'
 
 const Slide = ({ product }) => {
 	const { t } = useTranslation()
@@ -31,16 +32,18 @@ const Slide = ({ product }) => {
 	}
 	return (
 		<div className="popularOfThisArtistSliderCardContainer">
-			<div className="popularOfThisArtistSliderCardImgWrapper">
-				<img
-					className="popularOfThisArtistSliderCardImg"
-					src={featuredMediaUrl}
-					alt={t('Світлина мистецтва')}
-					onError={(e) => {
-						e.target.onerror = null
-						e.target.src = '/public/Img/newsCardERROR.jpg'
-					}}
-				/>
+                        <div className="popularOfThisArtistSliderCardImgWrapper">
+                                <Image
+                                        className="popularOfThisArtistSliderCardImg"
+                                        src={featuredMediaUrl}
+                                        alt={t('Світлина мистецтва')}
+                                        width={282}
+                                        height={282}
+                                        onError={(e) => {
+                                                e.target.onerror = null
+                                                e.target.src = '/public/Img/newsCardERROR.jpg'
+                                        }}
+                                />
 			</div>
 
 			<div className="popularOfThisArtistSliderSoldSellIconWrapper">

--- a/src/assets/components/Sliders/ArtistsPageSliders/ArtistsPageNewsArtistsSlider.jsx
+++ b/src/assets/components/Sliders/ArtistsPageSliders/ArtistsPageNewsArtistsSlider.jsx
@@ -16,6 +16,7 @@ import { useNavigate } from 'react-router-dom'
 import { getBaseUrl } from '../../../../utils/helper'
 import TranslatedContent from '../../Blocks/TranslatedContent'
 import '/src/styles/components/Sliders/Base/NewsSlider.scss'
+import Image from 'next/image'
 
 export const Slide = ({ post, baseUrl }) => {
 	const { t } = useTranslation()
@@ -35,17 +36,19 @@ export const Slide = ({ post, baseUrl }) => {
 				className="NewsSliderCardLink"
                                 onClick={handlePostClick}
 			>
-				<div className="NewsSliderCardImgWrapper">
-					<img
-						className="NewsSliderCardImg"
-						src={featuredMediaUrl}
-						alt={t('Світлина мистецтва')}
-						onClick={() => handlePostClick(post.id)}
-						onError={(e) => {
-							e.target.onerror = null
-							e.target.src = '/Img/newsCardERROR.jpg'
-						}}
-					/>
+                                <div className="NewsSliderCardImgWrapper">
+                                        <Image
+                                                className="NewsSliderCardImg"
+                                                src={featuredMediaUrl}
+                                                alt={t('Світлина мистецтва')}
+                                                width={282}
+                                                height={282}
+                                                onClick={() => handlePostClick(post.id)}
+                                                onError={(e) => {
+                                                        e.target.onerror = null
+                                                        e.target.src = '/Img/newsCardERROR.jpg'
+                                                }}
+                                        />
 				</div>
 
 				<div className="NewsSliderCardTitleWrapper">

--- a/src/assets/components/Sliders/ArtistsPageSliders/PopularArtsSlider.jsx
+++ b/src/assets/components/Sliders/ArtistsPageSliders/PopularArtsSlider.jsx
@@ -17,6 +17,7 @@ import '@styles/components/Sliders/Base/PopularSlider.scss'
 import { getBaseUrl, getImageUrl } from '../../../../utils/helper'
 // import LikeAndShare from '../../Blocks/LikeAndShare'
 import TranslatedContent from '../../Blocks/TranslatedContent'
+import Image from 'next/image'
 
 const Slide = ({ product, baseUrl }) => {
 	const { t, i18n } = useTranslation()
@@ -35,15 +36,17 @@ const Slide = ({ product, baseUrl }) => {
 	return (
 		<div className="PopularSliderCardWrapper">
 			<div className="PopularSliderCardInnerWrapper">
-				<img
-					className="PopularSliderCardImg"
-					src={imageUrl}
-					alt={t('Світлина мистецтва')}
-					onError={(e) => {
-						e.target.onerror = null
-						e.target.src = '/Img/mainPopularArtistsSlide.jpg'
-					}}
-				/>
+                                <Image
+                                        className="PopularSliderCardImg"
+                                        src={imageUrl}
+                                        alt={t('Світлина мистецтва')}
+                                        width={295}
+                                        height={430}
+                                        onError={(e) => {
+                                                e.target.onerror = null
+                                                e.target.src = '/Img/mainPopularArtistsSlide.jpg'
+                                        }}
+                                />
 			</div>
 			<div className="PopularSliderCardAbsoluteWrapper">
 				<div className="PopularSliderCardButtonWrapper">

--- a/src/assets/components/Sliders/ExhibitionPageSlider/ExhibitionPageMasonryGallery.jsx
+++ b/src/assets/components/Sliders/ExhibitionPageSlider/ExhibitionPageMasonryGallery.jsx
@@ -1,6 +1,7 @@
 import style from '@styles/components/Sliders/MasonrySlider/PageMasonryGallery.module.scss'
 import { debounce } from 'lodash' // Using lodash's debounce
 import PropTypes from 'prop-types'
+import Image from 'next/image'
 import {
 	memo,
 	useCallback,
@@ -624,22 +625,22 @@ const ExhibitionPageMasonryGallery = memo(
 												)
 											}
 										>
-											<img
-												src={img.src}
-												alt=""
-												loading="lazy"
-												className={style.galleryImage}
-												style={{
-													width: '100%',
-													height: '100%', // Let height adjust based on image aspect ratio
-													objectFit: 'cover', // Ensures the image covers the container without distortion
-												}}
-												onError={(e) => {
-													e.target.onerror = null
-													e.target.src =
-														'/Img/newsCardERROR.jpg'
-													console.error(
-														'Error loading gallery image:',
+                                                                              <Image
+                                                                              src={img.src}
+                                                                              alt=""
+                                                                              width={250}
+                                                                              height={250}
+                                                                              loading="lazy"
+                                                                              className={style.galleryImage}
+                                                                              style={{
+                                                                              objectFit: 'cover', // Ensures the image covers the container without distortion
+                                                                              }}
+                                                                              onError={(e) => {
+                                                                              e.target.onerror = null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
+                                                                              console.error(
+                                                                              'Error loading gallery image:',
 														e.target.src,
 													)
 												}}
@@ -686,22 +687,22 @@ const ExhibitionPageMasonryGallery = memo(
 												)
 											}
 										>
-											<img
-												src={img.src}
-												alt=""
-												loading="lazy"
-												className={style.galleryImage}
-												style={{
-													width: '100%',
-													height: '100%',
-													objectFit: 'cover',
-												}}
-												onError={(e) => {
-													e.target.onerror = null
-													e.target.src =
-														'/Img/newsCardERROR.jpg'
-													console.error(
-														'Error loading gallery image:',
+                                                                              <Image
+                                                                              src={img.src}
+                                                                              alt=""
+                                                                              width={250}
+                                                                              height={250}
+                                                                              loading="lazy"
+                                                                              className={style.galleryImage}
+                                                                              style={{
+                                                                              objectFit: 'cover',
+                                                                              }}
+                                                                              onError={(e) => {
+                                                                              e.target.onerror = null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
+                                                                              console.error(
+                                                                              'Error loading gallery image:',
 														e.target.src,
 													)
 												}}
@@ -748,22 +749,22 @@ const ExhibitionPageMasonryGallery = memo(
 												)
 											}
 										>
-											<img
-												src={img.src}
-												alt=""
-												loading="lazy"
-												className={style.galleryImage}
-												style={{
-													width: '100%',
-													height: '100%',
-													objectFit: 'cover',
-												}}
-												onError={(e) => {
-													e.target.onerror = null
-													e.target.src =
-														'/Img/newsCardERROR.jpg'
-													console.error(
-														'Error loading gallery image:',
+                                                                              <Image
+                                                                              src={img.src}
+                                                                              alt=""
+                                                                              width={250}
+                                                                              height={250}
+                                                                              loading="lazy"
+                                                                              className={style.galleryImage}
+                                                                              style={{
+                                                                              objectFit: 'cover',
+                                                                              }}
+                                                                              onError={(e) => {
+                                                                              e.target.onerror = null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
+                                                                              console.error(
+                                                                              'Error loading gallery image:',
 														e.target.src,
 													)
 												}}
@@ -1017,24 +1018,22 @@ const ExhibitionPageMasonryGallery = memo(
 																		'inline-block',
 																}}
 															>
-																<img
-																	src={`${baseUrl}${image.imageUrl.replace('../../', '/')}`}
-																	alt={`Product Image ${index + 1}`}
-																	loading="lazy"
-																	className={
-																		style.modalImage
-																	}
-																	style={{
-																		width: '100%',
-																		height: 'auto',
-																	}}
-																	onError={(
-																		e,
-																	) => {
-																		e.target.onerror =
-																			null
-																		e.target.src =
-																			'/Img/newsCardERROR.jpg'
+                                                                              <Image
+                                                                              src={`${baseUrl}${image.imageUrl.replace('../../', '/')}`}
+                                                                              alt={`Product Image ${index + 1}`}
+                                                                              width={500}
+                                                                              height={320}
+                                                                              loading="lazy"
+                                                                              className={
+                                                                              style.modalImage
+                                                                              }
+                                                                              onError={(
+                                                                              e,
+                                                                              ) => {
+                                                                              e.target.onerror =
+                                                                              null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
 																		console.error(
 																			'Error loading modal image:',
 																			e

--- a/src/assets/components/Sliders/ExhibitionPageSlider/ExhibitionPageNewsPopularExhibition.jsx
+++ b/src/assets/components/Sliders/ExhibitionPageSlider/ExhibitionPageNewsPopularExhibition.jsx
@@ -17,6 +17,7 @@ import '@styles/components/Sliders/Base/PopularSlider.scss'
 import { getBaseUrl, getImageUrl } from '../../../../utils/helper'
 // import LikeAndShare from '../../Blocks/LikeAndShare'
 import TranslatedContent from '../../Blocks/TranslatedContent'
+import Image from 'next/image'
 
 const Slide = ({ exhibition, baseUrl, onClick }) => {
 	const { t } = useTranslation()
@@ -38,15 +39,17 @@ const Slide = ({ exhibition, baseUrl, onClick }) => {
 	return (
 		<div className="PopularSliderCardWrapper">
 			<div className="PopularSliderCardInnerWrapper">
-				<img
-					className="PopularSliderCardImg"
-					src={imageUrl}
-					alt={t('Світлина мистецтва')}
-					onError={(e) => {
-						e.target.onerror = null
-						e.target.src = '/Img/mainPopularArtistsSlide.jpg'
-					}}
-				/>
+                                <Image
+                                        className="PopularSliderCardImg"
+                                        src={imageUrl}
+                                        alt={t('Світлина мистецтва')}
+                                        width={295}
+                                        height={430}
+                                        onError={(e) => {
+                                                e.target.onerror = null
+                                                e.target.src = '/Img/mainPopularArtistsSlide.jpg'
+                                        }}
+                                />
 			</div>
 			<div className="PopularSliderCardAbsoluteWrapper">
 				<div className="PopularSliderCardButtonWrapper">

--- a/src/assets/components/Sliders/ExhibitionsPageSlider/ExhibitionsPageNewsSlider.jsx
+++ b/src/assets/components/Sliders/ExhibitionsPageSlider/ExhibitionsPageNewsSlider.jsx
@@ -15,6 +15,7 @@ import { Navigation, Pagination } from 'swiper/modules'
 import { useNavigate } from 'react-router-dom'
 import { getBaseUrl } from '../../../../utils/helper'
 import TranslatedContent from '../../Blocks/TranslatedContent'
+import Image from 'next/image'
 import '/src/styles/components/Sliders/Base/NewsSlider.scss'
 export const Slide = ({ post, baseUrl }) => {
 	const { t } = useTranslation()
@@ -34,17 +35,19 @@ export const Slide = ({ post, baseUrl }) => {
 				className="NewsSliderCardLink"
                                 onClick={handlePostClick}
 			>
-				<div className="NewsSliderCardImgWrapper">
-					<img
-						className="NewsSliderCardImg"
-						src={featuredMediaUrl}
-						alt={t('Світлина мистецтва')}
-						onClick={() => handlePostClick(post.id)}
-						onError={(e) => {
-							e.target.onerror = null
-							e.target.src = '/Img/newsCardERROR.jpg'
-						}}
-					/>
+                                <div className="NewsSliderCardImgWrapper">
+                                        <Image
+                                                className="NewsSliderCardImg"
+                                                src={featuredMediaUrl}
+                                                alt={t('Світлина мистецтва')}
+                                                width={282}
+                                                height={282}
+                                                onClick={() => handlePostClick(post.id)}
+                                                onError={(e) => {
+                                                        e.target.onerror = null
+                                                        e.target.src = '/Img/newsCardERROR.jpg'
+                                                }}
+                                        />
 				</div>
 
 				<div className="NewsSliderCardTitleWrapper">

--- a/src/assets/components/Sliders/ExhibitionsPageSlider/ExhibitionsPagePopularExhibitions.jsx
+++ b/src/assets/components/Sliders/ExhibitionsPageSlider/ExhibitionsPagePopularExhibitions.jsx
@@ -14,6 +14,8 @@ import 'swiper/css/pagination'
 import { useNavigate } from 'react-router-dom'
 import { Navigation, Pagination } from 'swiper/modules'
 
+import Image from 'next/image'
+
 import '@styles/components/Sliders/Base/PopularSlider.scss'
 import { getBaseUrl, getImageUrl } from '../../../../utils/helper'
 // import LikeAndShare from '../../Blocks/LikeAndShare'
@@ -39,15 +41,17 @@ const Slide = ({ exhibition, baseUrl, onClick }) => {
 	return (
 		<div className="PopularSliderCardWrapper">
 			<div className="PopularSliderCardInnerWrapper">
-				<img
-					className="PopularSliderCardImg"
-					src={imageUrl}
-					alt={t('Світлина мистецтва')}
-					onError={(e) => {
-						e.target.onerror = null
-						e.target.src = '/Img/mainPopularArtistsSlide.jpg'
-					}}
-				/>
+                                <Image
+                                        className="PopularSliderCardImg"
+                                        src={imageUrl}
+                                        alt={t('Світлина мистецтва')}
+                                        width={295}
+                                        height={430}
+                                        onError={(e) => {
+                                                e.target.onerror = null
+                                                e.target.src = '/Img/mainPopularArtistsSlide.jpg'
+                                        }}
+                                />
 			</div>
 			<div className="PopularSliderCardAbsoluteWrapper">
 				<div className="PopularSliderCardButtonWrapper">

--- a/src/assets/components/Sliders/ExhibitionsPageSlider/ExhibitionsPageTopSlider.jsx
+++ b/src/assets/components/Sliders/ExhibitionsPageSlider/ExhibitionsPageTopSlider.jsx
@@ -12,6 +12,8 @@ import 'swiper/css/pagination'
 import { Autoplay } from 'swiper/modules'
 import { getBaseUrl, getImageUrl } from '../../../../utils/helper'
 
+import Image from 'next/image'
+
 // Import Swiper modules
 import { Navigation, Pagination } from 'swiper/modules'
 
@@ -91,17 +93,19 @@ const Slide = ({ museum, exhibition, baseUrl, onClick }) => {
 					</div>
 				</div>
 
-				<div className="BannerSliderCardImgWrapper">
-					<img
-						className="BannerSliderCardImg"
-						src={featuredMediaUrl}
-						alt={t('Фото музея')}
-						onError={(e) => {
-							e.target.onerror = null
-							e.target.src = '/Img/newsCardERROR.jpg'
-						}}
-					/>
-				</div>
+                                <div className="BannerSliderCardImgWrapper">
+                                        <Image
+                                                className="BannerSliderCardImg"
+                                                src={featuredMediaUrl}
+                                                alt={t('Фото музея')}
+                                                width={630}
+                                                height={330}
+                                                onError={(e) => {
+                                                        e.target.onerror = null
+                                                        e.target.src = '/Img/newsCardERROR.jpg'
+                                                }}
+                                        />
+                                </div>
 			</div>
 		</div>
 	)

--- a/src/assets/components/Sliders/MainPageBannerSlider/MainPageBannerSlider.jsx
+++ b/src/assets/components/Sliders/MainPageBannerSlider/MainPageBannerSlider.jsx
@@ -15,6 +15,7 @@ import { getBaseUrl, getImageUrl } from '../../../../utils/helper'
 import { Navigation, Pagination } from 'swiper/modules'
 
 import '/src/styles/components/Sliders/MainPageBannerSlider/MainPageBannerSlider.scss'
+import Image from 'next/image'
 
 const Slide = ({ museum, baseUrl, onClick }) => {
 	const { t } = useTranslation()
@@ -78,17 +79,19 @@ const Slide = ({ museum, baseUrl, onClick }) => {
 					</div>
 				</div>
 
-				<div className="BannerSliderCardImgWrapper">
-					<img
-						className="BannerSliderCardImg"
-						src={featuredMediaUrl}
-						alt={t('Фото музея')}
-						onError={(e) => {
-							e.target.onerror = null
-							e.target.src = '/Img/newsCardERROR.jpg'
-						}}
-					/>
-				</div>
+                                <div className="BannerSliderCardImgWrapper">
+                                        <Image
+                                                className="BannerSliderCardImg"
+                                                src={featuredMediaUrl}
+                                                alt={t('Фото музея')}
+                                                width={630}
+                                                height={330}
+                                                onError={(e) => {
+                                                        e.target.onerror = null
+                                                        e.target.src = '/Img/newsCardERROR.jpg'
+                                                }}
+                                        />
+                                </div>
 			</div>
 		</div>
 	)

--- a/src/assets/components/Sliders/MainPopularArtsSlider/MainPopularArtsSlider.jsx
+++ b/src/assets/components/Sliders/MainPopularArtsSlider/MainPopularArtsSlider.jsx
@@ -16,6 +16,7 @@ import { Navigation, Pagination } from 'swiper/modules'
 import { getBaseUrl, getImageUrl } from '../../../../utils/helper'
 import ModalWindow from '../../Blocks/ModalWindow'
 import TranslatedContent from '../../Blocks/TranslatedContent'
+import Image from 'next/image'
 
 const Slide = ({ product, baseUrl, onOverviewClick }) => {
 	const { t } = useTranslation()
@@ -49,16 +50,18 @@ const Slide = ({ product, baseUrl, onOverviewClick }) => {
 			// onClick={() => onOverviewClick(product)}
 			onClick={() => handleProductClick(product.id)}
 		>
-			<div className="PopularSliderCardInnerWrapper">
-				<img
-					className="PopularSliderCardImg"
-					src={imageUrl}
-					alt={t('Світлина мистецтва')}
-					onError={(e) => {
-						e.target.onerror = null
-						e.target.src = '/Img/newsCardERROR.jpg'
-					}}
-				/>
+                        <div className="PopularSliderCardInnerWrapper">
+                                <Image
+                                        className="PopularSliderCardImg"
+                                        src={imageUrl}
+                                        alt={t('Світлина мистецтва')}
+                                        width={295}
+                                        height={430}
+                                        onError={(e) => {
+                                                e.target.onerror = null
+                                                e.target.src = '/Img/newsCardERROR.jpg'
+                                        }}
+                                />
 			</div>
 			<div className="PopularSliderCardAbsoluteWrapper">
 				<div className="PopularSliderCardButtonWrapper">

--- a/src/assets/components/Sliders/MuseumPageSliders/MuseumPageMasonryGallery.jsx
+++ b/src/assets/components/Sliders/MuseumPageSliders/MuseumPageMasonryGallery.jsx
@@ -3,6 +3,7 @@
 import style from '@styles/components/Sliders/MasonrySlider/PageMasonryGallery.module.scss'
 import { debounce } from 'lodash' // Using lodash's debounce
 import PropTypes from 'prop-types'
+import Image from 'next/image'
 import {
 	useCallback,
 	useEffect,
@@ -591,22 +592,22 @@ const MuseumPageMasonryGallery = ({ products, baseUrl, museum }) => {
 											)
 										}
 									>
-										<img
-											src={img.src}
-											alt=""
-											loading="lazy"
-											className={style.galleryImage}
-											style={{
-												width: '100%',
-												height: '100%', // Let height adjust based on image aspect ratio
-												objectFit: 'cover', // Ensures the image covers the container without distortion
-											}}
-											onError={(e) => {
-												e.target.onerror = null
-												e.target.src =
-													'/Img/newsCardERROR.jpg'
-												console.error(
-													'Error loading gallery image:',
+                                                                              <Image
+                                                                              src={img.src}
+                                                                              alt=""
+                                                                              width={250}
+                                                                              height={250}
+                                                                              loading="lazy"
+                                                                              className={style.galleryImage}
+                                                                              style={{
+                                                                              objectFit: 'cover', // Ensures the image covers the container without distortion
+                                                                              }}
+                                                                              onError={(e) => {
+                                                                              e.target.onerror = null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
+                                                                              console.error(
+                                                                              'Error loading gallery image:',
 													e.target.src,
 												)
 											}}
@@ -652,20 +653,20 @@ const MuseumPageMasonryGallery = ({ products, baseUrl, museum }) => {
 											)
 										}
 									>
-										<img
-											src={img.src}
-											alt=""
-											loading="lazy"
-											className={style.galleryImage}
-											style={{
-												width: '100%',
-												height: '100%',
-												objectFit: 'cover',
-											}}
-											onError={(e) => {
-												e.target.onerror = null
-												e.target.src =
-													'/Img/newsCardERROR.jpg'
+                                                                              <Image
+                                                                              src={img.src}
+                                                                              alt=""
+                                                                              width={250}
+                                                                              height={250}
+                                                                              loading="lazy"
+                                                                              className={style.galleryImage}
+                                                                              style={{
+                                                                              objectFit: 'cover',
+                                                                              }}
+                                                                              onError={(e) => {
+                                                                              e.target.onerror = null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
 												console.error(
 													'Error loading gallery image:',
 													e.target.src,
@@ -713,20 +714,20 @@ const MuseumPageMasonryGallery = ({ products, baseUrl, museum }) => {
 											)
 										}
 									>
-										<img
-											src={img.src}
-											alt=""
-											loading="lazy"
-											className={style.galleryImage}
-											style={{
-												width: '100%',
-												height: '100%',
-												objectFit: 'cover',
-											}}
-											onError={(e) => {
-												e.target.onerror = null
-												e.target.src =
-													'/Img/newsCardERROR.jpg'
+                                                                              <Image
+                                                                              src={img.src}
+                                                                              alt=""
+                                                                              width={250}
+                                                                              height={250}
+                                                                              loading="lazy"
+                                                                              className={style.galleryImage}
+                                                                              style={{
+                                                                              objectFit: 'cover',
+                                                                              }}
+                                                                              onError={(e) => {
+                                                                              e.target.onerror = null
+                                                                              e.target.src =
+                                                                              '/Img/newsCardERROR.jpg'
 												console.error(
 													'Error loading gallery image:',
 													e.target.src,
@@ -1099,16 +1100,18 @@ const MuseumPageMasonryGallery = ({ products, baseUrl, museum }) => {
 						{t('Всі експонати цього музею ')}
 					</p>
 					``
-					<img
-						className={`${style.buttonArrow}`}
-						src={'/Img/buttonArrow.svg'}
-						alt={t('Фото митця')}
-						loading="lazy"
-						onError={(e) => {
-							e.target.onerror = null
-							e.target.src = '/Img/newsCardERROR.jpg'
-						}}
-					/>
+                                        <Image
+                                                className={`${style.buttonArrow}`}
+                                                src={'/Img/buttonArrow.svg'}
+                                                alt={t('Фото митця')}
+                                                width={20}
+                                                height={20}
+                                                loading="lazy"
+                                                onError={(e) => {
+                                                        e.target.onerror = null
+                                                        e.target.src = '/Img/newsCardERROR.jpg'
+                                                }}
+                                        />
 				</button>
 			</div>
 		</div>

--- a/src/assets/components/Sliders/MuseumsPageSliders/MuseumsPageNewsMuseum.jsx
+++ b/src/assets/components/Sliders/MuseumsPageSliders/MuseumsPageNewsMuseum.jsx
@@ -16,6 +16,7 @@ import { Navigation, Pagination } from 'swiper/modules'
 import { getBaseUrl } from '../../../../utils/helper'
 import TranslatedContent from '../../Blocks/TranslatedContent'
 import '/src/styles/components/Sliders/Base/NewsSlider.scss'
+import Image from 'next/image'
 
 const Slide = ({ post, baseUrl, onClick }) => {
 	const { t } = useTranslation()
@@ -32,17 +33,19 @@ const Slide = ({ post, baseUrl, onClick }) => {
 	return (
 		<div className="NewsSliderCardContainer">
 			<a className="NewsSliderCardLink">
-				<div className="NewsSliderCardImgWrapper">
-					<img
-						className="NewsSliderCardImg"
-						src={featuredMediaUrl}
-						alt={t('Світлина мистецтва')}
-						onClick={() => handlePostClick(post.id)}
-						onError={(e) => {
-							e.target.onerror = null
-							e.target.src = '/Img/newsCardERROR.jpg'
-						}}
-					/>
+                                <div className="NewsSliderCardImgWrapper">
+                                        <Image
+                                                className="NewsSliderCardImg"
+                                                src={featuredMediaUrl}
+                                                alt={t('Світлина мистецтва')}
+                                                width={282}
+                                                height={282}
+                                                onClick={() => handlePostClick(post.id)}
+                                                onError={(e) => {
+                                                        e.target.onerror = null
+                                                        e.target.src = '/Img/newsCardERROR.jpg'
+                                                }}
+                                        />
 				</div>
 
 				<div className="NewsSliderCardTitleWrapper">

--- a/src/assets/components/Sliders/MuseumsPageSliders/MuseumsPagePopularMuseums.jsx
+++ b/src/assets/components/Sliders/MuseumsPageSliders/MuseumsPagePopularMuseums.jsx
@@ -16,6 +16,7 @@ import { Navigation, Pagination } from 'swiper/modules'
 import { getBaseUrl, getImageUrl } from '../../../../utils/helper'
 // import LikeAndShare from '../../Blocks/LikeAndShare'
 import TranslatedContent from '../../Blocks/TranslatedContent'
+import Image from 'next/image'
 
 const Slide = ({ museum, baseUrl, onClick }) => {
 	const { t } = useTranslation()
@@ -25,15 +26,17 @@ const Slide = ({ museum, baseUrl, onClick }) => {
 	return (
 		<div className="PopularSliderCardWrapper">
 			<div className="PopularSliderCardInnerWrapper">
-				<img
-					className="PopularSliderCardImg"
-					src={featuredMediaUrl}
-					alt={t('Світлина мистецтва')}
-					onError={(e) => {
-						e.target.onerror = null
-						e.target.src = '/Img/mainPopularArtistsSlide.jpg'
-					}}
-				/>
+                                <Image
+                                        className="PopularSliderCardImg"
+                                        src={featuredMediaUrl}
+                                        alt={t('Світлина мистецтва')}
+                                        width={295}
+                                        height={430}
+                                        onError={(e) => {
+                                                e.target.onerror = null
+                                                e.target.src = '/Img/mainPopularArtistsSlide.jpg'
+                                        }}
+                                />
 			</div>
 			<div className="PopularSliderCardAbsoluteWrapper">
 				<div className="PopularSliderCardButtonWrapper">

--- a/src/assets/components/Sliders/MuseumsPageSliders/MuseumsPageTopSlider.jsx
+++ b/src/assets/components/Sliders/MuseumsPageSliders/MuseumsPageTopSlider.jsx
@@ -11,6 +11,8 @@ import 'swiper/css/pagination'
 import { Autoplay } from 'swiper/modules'
 import { getBaseUrl, getImageUrl } from '../../../../utils/helper'
 
+import Image from 'next/image'
+
 // Import Swiper modules
 import { Navigation, Pagination } from 'swiper/modules'
 
@@ -81,17 +83,19 @@ const Slide = ({ museum, baseUrl, onClick }) => {
 					</div>
 				</div>
 
-				<div className="BannerSliderCardImgWrapper">
-					<img
-						className="BannerSliderCardImg"
-						src={featuredMediaUrl}
-						alt={t('Фото музея')}
-						onError={(e) => {
-							e.target.onerror = null
-							e.target.src = '/Img/newsCardERROR.jpg'
-						}}
-					/>
-				</div>
+                                <div className="BannerSliderCardImgWrapper">
+                                        <Image
+                                                className="BannerSliderCardImg"
+                                                src={featuredMediaUrl}
+                                                alt={t('Фото музея')}
+                                                width={630}
+                                                height={330}
+                                                onError={(e) => {
+                                                        e.target.onerror = null
+                                                        e.target.src = '/Img/newsCardERROR.jpg'
+                                                }}
+                                        />
+                                </div>
 			</div>
 		</div>
 	)

--- a/src/assets/components/Sliders/NewsPageAuthorsSlider/NewsPageAuthorsSlider.jsx
+++ b/src/assets/components/Sliders/NewsPageAuthorsSlider/NewsPageAuthorsSlider.jsx
@@ -13,6 +13,7 @@ import { Navigation, Pagination } from 'swiper/modules'
 
 import { getBaseUrl } from '../../../../utils/helper'
 import '/src/styles/components/Sliders/NewsPageAuthorsSlider/NewsPageAuthorsSlider.scss'
+import Image from 'next/image'
 
 const Slide = ({ author, onClick }) => {
 	const { t } = useTranslation()
@@ -20,23 +21,25 @@ const Slide = ({ author, onClick }) => {
 	return (
 		<div className="newsPageAuthorsSliderCardContainer">
 			<div className="newsPageAuthorsSliderCardWrapper">
-				<div className="newsPageAuthorsSliderCardUserPhotoWrapper">
-					<img
-						className="newsPageAuthorsSliderCardUserPhoto"
-						src={
-							author.images
-								? `${baseUrl}${author.images.replace('../../', '/')}`
-								: '/Img/halfNewsCard.jpg'
-						}
-						alt={t('Фотографія автора')}
-						loading="lazy"
-						onClick={() => onClick(author.id)}
-						onError={(e) => {
-							e.target.onerror = null
-							e.target.src =
-								'/Img/mainInstagramSliderUserPhoto.png'
-						}}
-					/>
+                                <div className="newsPageAuthorsSliderCardUserPhotoWrapper">
+                                        <Image
+                                                className="newsPageAuthorsSliderCardUserPhoto"
+                                                src={
+                                                        author.images
+                                                                ? `${baseUrl}${author.images.replace('../../', '/')}`
+                                                                : '/Img/halfNewsCard.jpg'
+                                                }
+                                                alt={t('Фотографія автора')}
+                                                width={125}
+                                                height={125}
+                                                loading="lazy"
+                                                onClick={() => onClick(author.id)}
+                                                onError={(e) => {
+                                                        e.target.onerror = null
+                                                        e.target.src =
+                                                                '/Img/mainInstagramSliderUserPhoto.png'
+                                                }}
+                                        />
 				</div>
 				<div className="newsPageAuthorsSliderCardUserNameWrapper">
 					<p className="newsPageAuthorsSliderCardUserName">

--- a/src/assets/components/Sliders/PostDetailPopularNewsSlider/PostDetailPopularNewsSlider.jsx
+++ b/src/assets/components/Sliders/PostDetailPopularNewsSlider/PostDetailPopularNewsSlider.jsx
@@ -15,6 +15,7 @@ import { useNavigate } from 'react-router-dom'
 import { Navigation, Pagination } from 'swiper/modules'
 import { getBaseUrl, getImageUrl } from '../../../../utils/helper'
 import TranslatedContent from '../../Blocks/TranslatedContent'
+import Image from 'next/image'
 
 const Slide = ({ post, baseUrl }) => {
 	const { t } = useTranslation()
@@ -29,15 +30,17 @@ const Slide = ({ post, baseUrl }) => {
 	return (
 		<div className="PopularSliderCardWrapper">
 			<div className="PopularSliderCardInnerWrapper">
-				<img
-					className="PopularSliderCardImg"
-					src={imageUrl}
-					alt={t('Світлина мистецтва')}
-					onError={(e) => {
-						e.target.onerror = null
-						e.target.src = '/Img/newsCardERROR.jpg'
-					}}
-				/>
+                                <Image
+                                        className="PopularSliderCardImg"
+                                        src={imageUrl}
+                                        alt={t('Світлина мистецтва')}
+                                        width={295}
+                                        height={430}
+                                        onError={(e) => {
+                                                e.target.onerror = null
+                                                e.target.src = '/Img/newsCardERROR.jpg'
+                                        }}
+                                />
 			</div>
 			<div className="PopularSliderCardAbsoluteWrapper">
 				<div className="PopularSliderCardButtonWrapper">


### PR DESCRIPTION
## Summary
- refactor slider components to use `Image` from `next/image`
- specify width and height for images

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436c456e388323a34f2ee59e0c7c92