### PR TITLE
Allow images from remote domain

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,7 @@ REACT_APP_API_URL=http://localhost:5000
 # For production you might use the following:
 # NEXT_PUBLIC_API_URL=https://art.playukraine.com
 # REACT_APP_API_URL=https://art.playukraine.com
+# NEXT_PUBLIC_PROD_API_URL=https://art.playukraine.com/api/
 
 # Google Analytics
 # NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX

--- a/next.config.js
+++ b/next.config.js
@@ -1,2 +1,13 @@
-const config = {};
+const config = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'art.playukraine.com',
+        pathname: '/**',
+      },
+    ],
+  },
+};
+
 export default config;


### PR DESCRIPTION
## Summary
- allow remote image paths from art.playukraine.com in `next.config.js`
- document production API base URL in `.env.sample`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843723eaab48323beeee17931026be1