### PR TITLE
Update base URL helper

### DIFF
--- a/__tests__/helper.test.js
+++ b/__tests__/helper.test.js
@@ -3,7 +3,9 @@ import { getImageUrl, getFormattedDate, getFormattedTime } from '../src/utils/he
 
 describe('helper utilities', () => {
   beforeEach(() => {
-    global.window = { location: { hostname: 'localhost' } };
+    global.window = {
+      location: { hostname: 'localhost', origin: 'http://localhost:3000' },
+    };
     process.env.NEXT_PUBLIC_API_URL = 'http://localhost:5000';
   });
 
@@ -20,6 +22,13 @@ describe('helper utilities', () => {
     test('normalizes relative paths', () => {
       const result = getImageUrl('images/pic.jpg');
       expect(result).toBe('http://localhost:5000/images/pic.jpg');
+    });
+
+    test('uses window origin for non-localhost', () => {
+      global.window.location.hostname = 'example.com';
+      global.window.location.origin = 'https://example.com';
+      const result = getImageUrl('images/pic.jpg');
+      expect(result).toBe('https://example.com/images/pic.jpg');
     });
   });
 

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,13 +1,19 @@
 export function getBaseUrl() {
-        const host =
-                typeof window !== 'undefined'
-                        ? window.location.hostname
-                        : process.env.NEXT_PUBLIC_HOST || 'localhost'
+        const isBrowser = typeof window !== 'undefined'
+        const host = isBrowser
+                ? window.location.hostname
+                : process.env.NEXT_PUBLIC_HOST || 'localhost'
+
         const isLocalhost = host === 'localhost' || host === '127.0.0.1'
-        const baseUrl = isLocalhost
-                ? process.env.NEXT_PUBLIC_API_URL
-                : 'https://art.playukraine.com'
-        return baseUrl
+        if (isLocalhost) {
+                return process.env.NEXT_PUBLIC_API_URL
+        }
+
+        if (isBrowser) {
+                return window.location.origin
+        }
+
+        return `https://${host}`
 }
 
 /**


### PR DESCRIPTION
## Summary
- compute base URL from the browser's origin when not on localhost
- adjust helper tests for new origin logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437451ea5c8323959eb30f9c96536c