### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  test-and-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Start production server
+        run: npm run start &
+
+      - name: Wait for server
+        run: npx wait-on http://localhost:3000/main-page
+
+      - name: Smoke-test /img/placeholder.jpg
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/img/placeholder.jpg)
+          if [ "$STATUS" != "200" ]; then
+            echo "Smoke-test failed: HTTP $STATUS"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run unit tests and a smoke-test

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: dependency resolution errors)*
- `git push` *(fails: no configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_6843888f99a483239159b8d7308ddc61