### PR TITLE
Update README installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,20 @@ This project uses **Next.js** for server-side rendering (SSR).
 
 ## Getting Started
 
-Install dependencies and create a local `.env` file based on `.env.sample`:
+This project requires Node 18 or later. Install dependencies and create a local `.env` file based on `.env.sample`:
 
 ```bash
 npm install
 ```
+
+If you see peer dependency errors, try:
+
+```bash
+npm install --legacy-peer-deps
+```
+
+Tests rely on an up-to-date `package-lock.json`.
+
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- explain Node 18 requirement
- describe using `npm install` with optional `--legacy-peer-deps`
- note that tests rely on `package-lock.json`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps` *(fails: integrity checksum error)*

------
https://chatgpt.com/codex/tasks/task_e_6843a130090c83239fc0e58e695063ef