### PR TITLE
Fix fallback paths and remove leftover /Img references

### DIFF
--- a/src/assets/components/Blocks/MainArtists.jsx
+++ b/src/assets/components/Blocks/MainArtists.jsx
@@ -114,7 +114,7 @@ function MainArtists() {
 							alt={t('Стрілка')}
 							onError={(e) => {
 								e.target.onerror = null
-								e.target.src = '/mainNewImg/buttonArrow.svg'
+                                                                e.target.src = '/img/buttonArrow.svg'
 							}}
 						/>
 					</button> */}
@@ -270,7 +270,7 @@ function MainArtists() {
 						alt={t('Стрілка')}
 						onError={(e) => {
 							e.target.onerror = null
-							e.target.src = '/mainNewImg/buttonArrow.svg'
+                                                        e.target.src = '/img/buttonArrow.svg'
 						}}
 					/>
 				</button>

--- a/src/assets/components/Blocks/MainExhibitions.jsx
+++ b/src/assets/components/Blocks/MainExhibitions.jsx
@@ -111,7 +111,7 @@ function MainExhibitions() {
 							alt={t('Стрілка')}
 							onError={(e) => {
 								e.target.onerror = null
-								e.target.src = '/mainNewImg/buttonArrow.svg'
+                                                                e.target.src = '/img/buttonArrow.svg'
 							}}
 						/>
 					</button> */}
@@ -296,7 +296,7 @@ function MainExhibitions() {
 						alt={t('Стрілка')}
 						onError={(e) => {
 							e.target.onerror = null
-							e.target.src = '/mainNewImg/buttonArrow.svg'
+                                                        e.target.src = '/img/buttonArrow.svg'
 						}}
 					/>
 				</button>

--- a/src/assets/components/Blocks/MainMuseums.jsx
+++ b/src/assets/components/Blocks/MainMuseums.jsx
@@ -112,7 +112,7 @@ function MainMuseums() {
 							alt={t('Стрілка')}
 							onError={(e) => {
 								e.target.onerror = null
-								e.target.src = '/mainNewImg/buttonArrow.svg'
+                                                                e.target.src = '/img/buttonArrow.svg'
 							}}
 						/>
 					</button> */}
@@ -261,7 +261,7 @@ function MainMuseums() {
 						alt={t('Стрілка')}
 						onError={(e) => {
 							e.target.onerror = null
-							e.target.src = '/mainNewImg/buttonArrow.svg'
+                                                        e.target.src = '/img/buttonArrow.svg'
 						}}
 					/>
 				</button>

--- a/src/assets/components/Blocks/MainNews.jsx
+++ b/src/assets/components/Blocks/MainNews.jsx
@@ -112,7 +112,7 @@ function MainNews() {
 							alt={t('Стрілка')}
 							onError={(e) => {
 								e.target.onerror = null
-								e.target.src = '/mainNewImg/buttonArrow.svg'
+                                                                e.target.src = '/img/buttonArrow.svg'
 							}}
 						/>
 					</button> */}
@@ -268,7 +268,7 @@ function MainNews() {
 						alt={t('Стрілка')}
 						onError={(e) => {
 							e.target.onerror = null
-							e.target.src = '/mainNewImg/buttonArrow.svg'
+                                                        e.target.src = '/img/buttonArrow.svg'
 						}}
 					/>
 				</button>

--- a/src/assets/screens/newsPage/NewsPage.jsx
+++ b/src/assets/screens/newsPage/NewsPage.jsx
@@ -330,7 +330,7 @@ function NewsPage() {
 								alt={t('Стрілка')}
 								onError={(e) => {
 									e.target.onerror = null
-									e.target.src = '/mainNewImg/buttonArrow.svg' // Fallback image
+                                                                        e.target.src = '/img/buttonArrow.svg' // Fallback image
 								}}
 							/>
 						</button>) : null}


### PR DESCRIPTION
## Summary
- update buttonArrow fallback paths to use `/img` directory
- clean up remaining `/Img` references

## Testing
- `npm test` *(fails: jest not found)*
- `grep -R "/mainNewImg/buttonArrow.svg" src`
- `grep -R "/Img/" src public | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684419b5f8408323be6257a4bb715fc7