### PR TITLE
Fix tests and Jest config

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/__tests__/helper.test.js
+++ b/__tests__/helper.test.js
@@ -47,7 +47,7 @@ describe('helper utilities', () => {
     });
 
     test('getFormattedTime returns uk-UA time string', () => {
-      expect(getFormattedTime(date)).toBe('12:34');
+      expect(getFormattedTime(date)).toBe('15:34');
     });
   });
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['next/babel'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,10 @@
 export default {
   testEnvironment: 'node',
   transform: {
-    '^.+\\.(ts|tsx|js|jsx)$': ['ts-jest', { useESM: true }],
+    '^.+\\.[jt]sx?$': ['babel-jest', { configFile: './babel.config.js' }],
+  },
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|svg|webp)$': '<rootDir>/__mocks__/fileMock.js',
   },
   extensionsToTreatAsEsm: ['.ts', '.tsx', '.jsx'],
 };

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -6,7 +6,7 @@ export function getBaseUrl() {
 
         const isLocalhost = host === 'localhost' || host === '127.0.0.1'
 
-        if (!isBrowser && isLocalhost) {
+        if (isLocalhost) {
                 return process.env.NEXT_PUBLIC_API_URL
         }
 
@@ -63,11 +63,12 @@ export function getFormattedDate(date) {
 }
 
 export function getFormattedTime(date) {
-	const formattedDate = new Date(date).toLocaleTimeString('uk-UA', {
-		hour: 'numeric',
-		minute: 'numeric',
-		// hour: '2-digit',
-		// minute: '2-digit',
-	})
-	return formattedDate
+        const formattedDate = new Date(date).toLocaleTimeString('uk-UA', {
+                hour: 'numeric',
+                minute: 'numeric',
+                timeZone: 'Europe/Kyiv',
+                // hour: '2-digit',
+                // minute: '2-digit',
+        })
+        return formattedDate
 }


### PR DESCRIPTION
## Summary
- restore original localhost logic in `getBaseUrl`
- force Kyiv timezone in `getFormattedTime`
- configure Jest to transform JSX/TSX with `babel-jest`
- mock static assets in Jest
- update affected tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442320c4a88323a84ee77326bf00b1