### PR TITLE
Fix tests by mocking Swiper and simplifying helper setup

### DIFF
--- a/__mocks__/swiper/modules.js
+++ b/__mocks__/swiper/modules.js
@@ -1,0 +1,4 @@
+module.exports = {
+  Navigation: () => null,
+  Pagination: () => null,
+};

--- a/__mocks__/swiper/react.js
+++ b/__mocks__/swiper/react.js
@@ -1,0 +1,6 @@
+const React = require('react');
+
+module.exports = {
+  Swiper: ({ children }) => React.createElement('div', { className: 'swiper-mock' }, children),
+  SwiperSlide: ({ children }) => React.createElement('div', { className: 'swiper-slide-mock' }, children),
+};

--- a/__tests__/Sliders.test.jsx
+++ b/__tests__/Sliders.test.jsx
@@ -9,8 +9,14 @@ jest.mock('react-router-dom', () => ({
 }))
 
 jest.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key) => key }),
+  useTranslation: () => ({ t: (key) => key, i18n: { language: 'en' } }),
 }))
+
+jest.mock('swiper/react')
+jest.mock('swiper/modules')
+jest.mock('swiper/css', () => ({}))
+jest.mock('swiper/css/navigation', () => ({}))
+jest.mock('swiper/css/pagination', () => ({}))
 
 describe('Slider slides navigation', () => {
   test('artist slide navigates on click', () => {

--- a/__tests__/helper.test.js
+++ b/__tests__/helper.test.js
@@ -1,14 +1,12 @@
+/** @jest-environment node */
 import { jest } from '@jest/globals';
 import { getImageUrl, getFormattedDate, getFormattedTime, getBaseUrl } from '../src/utils/helper.js';
 
 describe('helper utilities', () => {
   beforeEach(() => {
-    global.window = {};
-    Object.defineProperty(global.window, 'location', {
-      value: { hostname: 'localhost', origin: 'http://localhost:3000' },
-      writable: true,
-      configurable: true,
-    });
+    global.window = {
+      location: { hostname: 'localhost', origin: 'http://localhost:3000' },
+    };
     process.env.NEXT_PUBLIC_API_URL = 'http://localhost:5000';
   });
 
@@ -28,12 +26,9 @@ describe('helper utilities', () => {
     });
 
     test('uses window origin for non-localhost', () => {
-      global.window = {};
-      Object.defineProperty(global.window, 'location', {
-        value: { hostname: 'example.com', origin: 'https://example.com' },
-        writable: true,
-        configurable: true,
-      });
+      global.window = {
+        location: { hostname: 'example.com', origin: 'https://example.com' },
+      };
       const result = getImageUrl('images/pic.jpg');
       expect(result).toBe('https://example.com/images/pic.jpg');
     });
@@ -60,23 +55,17 @@ describe('helper utilities', () => {
 
   describe('getBaseUrl', () => {
     test('returns window origin for localhost', () => {
-      global.window = {};
-      Object.defineProperty(global.window, 'location', {
-        value: { hostname: 'localhost', origin: 'http://localhost:3000' },
-        writable: true,
-        configurable: true,
-      });
+      global.window = {
+        location: { hostname: 'localhost', origin: 'http://localhost:3000' },
+      };
       process.env.NEXT_PUBLIC_API_URL = 'http://localhost:5000';
       expect(getBaseUrl()).toBe('http://localhost:3000');
     });
 
     test('returns window origin for remote host', () => {
-      global.window = {};
-      Object.defineProperty(global.window, 'location', {
-        value: { hostname: 'example.com', origin: 'https://example.com' },
-        writable: true,
-        configurable: true,
-      });
+      global.window = {
+        location: { hostname: 'example.com', origin: 'https://example.com' },
+      };
       expect(getBaseUrl()).toBe('https://example.com');
     });
   });

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '\\.(css|scss)$': 'identity-obj-proxy',
+    '^swiper\\/css.*$': 'identity-obj-proxy',
     '\\.(jpg|jpeg|png|svg|ttf)$': '<rootDir>/__mocks__/fileMock.js',
   },
   testPathIgnorePatterns: ['/node_modules/', '/.next/'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint": "^8.46.0",
         "eslint-config-next": "^15.3.2",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
         "next-sitemap": "^4.2.3",
@@ -6269,6 +6270,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6468,6 +6476,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ignore": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
     "next": "^15.3.2",
+    "next-auth": "^4.24.11",
     "next-intl": "^3.4.2",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
@@ -38,13 +39,12 @@
     "react-router-dom": "^7.6.2",
     "react-toastify": "^11.0.5",
     "sass": "^1.89.1",
-    "swiper": "^11.2.8",
-    "next-auth": "^4.24.11"
+    "swiper": "^11.2.8"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
-    "@testing-library/dom": "^10.0.0",
     "@types/jest": "^29.5.4",
     "@types/node": "^22.15.30",
     "@types/react": "^18.2.0",
@@ -52,6 +52,7 @@
     "eslint": "^8.46.0",
     "eslint-config-next": "^15.3.2",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "next-sitemap": "^4.2.3",


### PR DESCRIPTION
## Summary
- simplify window mocking in helper tests by using Node environment
- mock Swiper modules and CSS imports in tests
- add identity-obj-proxy dev dependency
- map Swiper CSS imports in Jest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68446f07639083239fa4fbc0f81e11d8