### PR TITLE
Add Next.js ESLint plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,8 +12,7 @@
     "react-hooks",
     "jsx-a11y",
     "@typescript-eslint",
-    "import",
-    "next"
+    "import"
   ],
   "extends": [
     "eslint:recommended",

--- a/eslintrc.js
+++ b/eslintrc.js
@@ -12,8 +12,7 @@ module.exports = {
     'react-hooks',
     'jsx-a11y',
     '@typescript-eslint',
-    'import',
-    'next'
+    'import'
   ],
   extends: [
     'eslint:recommended',

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "swiper": "^11.2.8"
       },
       "devDependencies": {
+        "@next/eslint-plugin-next": "^15.3.3",
         "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "swiper": "^11.2.8"
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "^15.3.3",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
## Summary
- add `@next/eslint-plugin-next` to devDependencies
- remove unnecessary `next` entry from ESLint plugins in JS/JSON configs

## Testing
- `npm run lint` *(fails: jsx-a11y/html-has-lang, @next/next/no-html-link-for-pages)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448d0674ac832393e51682ba5c60b4