### PR TITLE
Fix navigation links in exhibition and art term components

### DIFF
--- a/__tests__/Sliders.test.jsx
+++ b/__tests__/Sliders.test.jsx
@@ -2,6 +2,7 @@
 import { render, fireEvent } from '@testing-library/react'
 import { Slide as ArtistSlide } from '../src/assets/components/Sliders/ArtistsPageSliders/ArtistsPageNewsArtistsSlider.jsx'
 import { Slide as ExhibitionSlide } from '../src/assets/components/Sliders/ExhibitionsPageSlider/ExhibitionsPageNewsSlider.jsx'
+import { Slide as ArtTermSlide } from '../src/assets/screens/ArtTerms/ArtTermSlider.jsx'
 import { useNavigate } from 'react-router-dom'
 
 jest.mock('react-router-dom', () => ({
@@ -35,5 +36,14 @@ describe('Slider slides navigation', () => {
     const { container } = render(<ExhibitionSlide post={post} baseUrl="" />)
     fireEvent.click(container.querySelector('.NewsSliderCardLink'))
     expect(navigate).toHaveBeenCalledWith(`/posts/${post.id}`)
+  })
+
+  test('art term slide navigates on click', () => {
+    const navigate = jest.fn()
+    useNavigate.mockReturnValue(navigate)
+    const artTerm = { id: 3, highlightedProduct: {}, title_en: 't', title_uk: 't', content_en: 'c', content_uk: 'c' }
+    const { container } = render(<ArtTermSlide artTerm={artTerm} baseUrl="" />)
+    fireEvent.click(container.querySelector('.NewsSliderCardLink'))
+    expect(navigate).toHaveBeenCalledWith(`/art-terms/${artTerm.id}`)
   })
 })

--- a/src/assets/components/Blocks/MainExhibitions.jsx
+++ b/src/assets/components/Blocks/MainExhibitions.jsx
@@ -267,13 +267,14 @@ function MainExhibitions() {
 									<div
 										className={`${styles.cardReadMoreWrapper}`}
 									>
-										{/*	TODO:write correct link */}
-										<a
-											href={`/exhibitions/${exhibition.id}`}
-											className={`${styles.cardReadMoreLink}`}
-										>
-											{t('Читати далі')}
-										</a>
+                                                                       <a
+                                                                               onClick={() =>
+                                                                                       handleExhibitionPageClick(exhibition.id)
+                                                                               }
+                                                                               className={`${styles.cardReadMoreLink}`}
+                                                                       >
+                                                                               {t('Читати далі')}
+                                                                       </a>
 									</div>
 								</div>
 							</div>

--- a/src/assets/screens/ArtTerms/ArtTermSlider.jsx
+++ b/src/assets/screens/ArtTerms/ArtTermSlider.jsx
@@ -15,10 +15,10 @@ import { Navigation, Pagination } from 'swiper/modules'
 // import sliderStyles from '@styles/components/Blocks/Slider.module.scss'
 import { useNavigate } from 'react-router-dom'
 import { getBaseUrl } from '../../../utils/helper'
-import TranslatedContent from '@components/Blocks/TranslatedContent'
+import TranslatedContent from '../../components/Blocks/TranslatedContent'
 import '@styles/components/Sliders/Base/ArtTermsSlider.scss'
 
-const Slide = ({ artTerm, baseUrl }) => {
+export const Slide = ({ artTerm, baseUrl }) => {
 	const { t } = useTranslation()
 	const navigate = useNavigate()
 
@@ -34,14 +34,14 @@ const Slide = ({ artTerm, baseUrl }) => {
 		<div className="NewsSliderCardContainer">
 			<a
 				className="NewsSliderCardLink"
-				// TODO:Rewrite component to use navigate for post	onClick={handleArtistPageClick}
+        onClick={handlePostClick}
 			>
 				<div className="NewsSliderCardImgWrapper">
 					<img
 						className="NewsSliderCardImg"
 						src={featuredMediaUrl}
 						alt={t('Світлина мистецтва')}
-						onClick={() => handlePostClick(artTerm.id)}
+						onClick={handlePostClick}
 						onError={(e) => {
 							e.target.onerror = null
 							e.target.src = '/Img/newsCardERROR.jpg'
@@ -51,7 +51,7 @@ const Slide = ({ artTerm, baseUrl }) => {
 
 				<div className="NewsSliderCardTitleWrapper">
 					<h3 className="NewsSliderCardTitle"
-						onClick={() => handlePostClick(artTerm.id)}>
+						onClick={handlePostClick}>
 						<TranslatedContent
 							en={artTerm.title_en}
 							uk={artTerm.title_uk}
@@ -62,7 +62,7 @@ const Slide = ({ artTerm, baseUrl }) => {
 
 				<div className="ArtTermsSliderCardDescriptionWrapper">
 					<p className="NewsSliderCardDescription"
-						onClick={() => handlePostClick(artTerm.id)}>
+						onClick={handlePostClick}>
 						<TranslatedContent
 							en={artTerm.content_en}
 							uk={artTerm.content_uk}


### PR DESCRIPTION
## Summary
- use navigate handler for MainExhibitions 'read more' links
- export ArtTermSlider slide and fix navigation
- add slider test for ArtTermSlider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684491351bf883238802cf219919f7d7