### PR TITLE
Fix lint errors in SSR pages

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 
 export default function GlobalError() {
   return (
-    <html>
+    <html lang="uk">
       <body style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}>
         <h1>Щось пішло не так…</h1>
         <p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 // Файл: /src/app/page.tsx
 
 import dynamic from 'next/dynamic'
+import Link from 'next/link'
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -44,10 +45,10 @@ export default function HomePage() {
 
       <ul>
         <li>
-          <a href="/news/1">{t('Перша новина')}</a>
+          <Link href="/news/1">{t('Перша новина')}</Link>
         </li>
         <li>
-          <a href="/news/2">{t('Друга новина')}</a>
+          <Link href="/news/2">{t('Друга новина')}</Link>
         </li>
       </ul>
 


### PR DESCRIPTION
## Summary
- add `lang` attribute to error page markup
- use `Link` components instead of `<a>` in homepage

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-next')*

------
https://chatgpt.com/codex/tasks/task_e_68449452357483239955a3855db907b7