### PR TITLE
Remove unused eslint plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "eslint-config-next": "^15.3.2",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-next": "^0.0.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
@@ -5449,13 +5448,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/eslint-plugin-next": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-next/-/eslint-plugin-next-0.0.0.tgz",
-      "integrity": "sha512-IldNDVb6WNduggwRbYzSGZhaskUwVecJ6fhmqwX01+S1aohwAWNzU4me6y47DDzpD/g0fdayNBGxEdt9vKkUtg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "eslint-config-next": "^15.3.2",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "eslint-plugin-next": "^0.0.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",


### PR DESCRIPTION
## Summary
- drop unused `eslint-plugin-next` from dev dependencies
- re-generate `package-lock.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844b2d2d6208323a374336e355d1843