### PR TITLE
Update ESLint next plugin usage

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,10 +14,10 @@ module.exports = {
     'react-hooks',
     'jsx-a11y',
     'import',
-    'next',
+    '@next/next',
   ],
   extends: [
-    'next/core-web-vitals',
+    'plugin:@next/next/core-web-vitals',
     'plugin:@typescript-eslint/recommended',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',


### PR DESCRIPTION
## Summary
- use `@next/next` ESLint plugin
- reference `@next/next` in extends
- ensure devDependencies use `@next/eslint-plugin-next`

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844c19e0cb48323b030964f9ca58bff