### PR TITLE
Switch to .babelrc for Jest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,1 @@
+{ "presets": ["next/babel"] }

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,4 +1,0 @@
-// babel.config.cjs
-module.exports = {
-  presets: ['next/babel'],
-};

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.[jt]sx?$': ['babel-jest', { configFile: './babel.config.cjs' }],
+    '^.+\\.[jt]sx?$': ['babel-jest'],
   },
   moduleNameMapper: {
     '\\.(css|scss)$': 'identity-obj-proxy',


### PR DESCRIPTION
## Summary
- delete `babel.config.cjs`
- add `.babelrc` for Next.js preset
- simplify Jest transform config to auto-detect `.babelrc`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844c8299a0083239e25d9941c1bec91