### PR TITLE
Remove Babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,0 @@
-{ "presets": ["next/babel"] }


### PR DESCRIPTION
## Summary
- remove custom Babel config to ensure SWC is used

## Testing
- `npm install --silent`
- `npm run build` *(fails: You are attempting to export `metadata` from a component marked with `use client`)*
- `npm test` *(fails to parse ESM syntax)*

------
https://chatgpt.com/codex/tasks/task_e_6844cb1d12288323a6b48e2893dc6a1c