### PR TITLE
Fix Jest setup file

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,1 @@
+module.exports = { presets: ['next/babel'] };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,5 +10,5 @@ module.exports = {
     '\\.(jpg|jpeg|png|svg|ttf|webp)$': '<rootDir>/__mocks__/fileMock.js',
   },
   testPathIgnorePatterns: ['/node_modules/', '/.next/'],
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.cjs'],
 };

--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -1,0 +1,1 @@
+require('@testing-library/jest-dom');

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary
- rename Jest setup file to `.cjs`
- require `@testing-library/jest-dom` instead of using `import`
- update Jest config
- add Babel config so tests run

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844cfc0ef608323ae04c66b889acb95