### PR TITLE
Switch Babel config to ES module

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,1 +1,0 @@
-module.exports = { presets: ['next/babel'] };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+export default {
+  presets: ['next/babel']
+};


### PR DESCRIPTION
## Summary
- remove legacy `babel.config.cjs`
- create `babel.config.js` using ES module syntax

## Testing
- `npm test`
- `npm run build` *(fails: `next/font` requires SWC due to custom babel config)*

------
https://chatgpt.com/codex/tasks/task_e_6844d2e2b870832393bf91cb7f358f99