### PR TITLE
Fix JSX closing tags

### DIFF
--- a/src/assets/screens/ExhibitionPage/ExhibitionPage.jsx
+++ b/src/assets/screens/ExhibitionPage/ExhibitionPage.jsx
@@ -423,7 +423,6 @@ function ExhibitionDetails() {
 							</p>
 						</div>
 					</div>
-				</div>
 			</div>
 		</div>
 	)


### PR DESCRIPTION
## Summary
- remove stray closing `div` tag in ExhibitionPage.jsx

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844dd327ddc83239c2951eceb89005b