### PR TITLE
Fix MuseumPage JSX closing tag

### DIFF
--- a/src/assets/screens/MuseumPage/MuseumPage.jsx
+++ b/src/assets/screens/MuseumPage/MuseumPage.jsx
@@ -251,7 +251,6 @@ function MuseumPage() {
 						</button>
 					</div>
 				</div>
-			</div>
 		</div>
 	)
 }


### PR DESCRIPTION
## Summary
- remove stray closing `<div>` from MuseumPage JSX

## Testing
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e015db248323b947163ccfc06372