### PR TITLE
Add API_BASE_URL env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,31 @@
 # Example environment variables for Art & Culture
-NEXT_PUBLIC_API_URL=http://localhost:5000 # browser & server
-REACT_APP_API_URL=http://localhost:5000 # browser
-NEXT_PUBLIC_HOST=localhost # server
-NEXT_PUBLIC_PROD_API_URL=https://art.playukraine.com/api/ # browser & server
-NEXT_PUBLIC_DEFAULT_WIDTH=1024 # server
-NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX # browser
-DATABASE_URL=postgres://user:password@localhost:5432/dbname # server
-REDIS_URL=redis://localhost:6379 # server
-UPSTASH_REDIS_REST_URL= # server
-UPSTASH_REDIS_REST_TOKEN= # server
-SHOPIFY_API_KEY= # server
-SHOPIFY_API_SECRET= # server
-NEXTAUTH_SECRET= # server
-GITHUB_ID= # server
-GITHUB_SECRET= # server
-TOKEN= # server
+# Base URL used by fetch() in server components
+API_BASE_URL=http://localhost:5000
+NEXT_PUBLIC_API_URL=http://localhost:5000
+REACT_APP_API_URL=http://localhost:5000
+# Host used when rendering on the server
+NEXT_PUBLIC_HOST=localhost
+# For production you might use the following:
+# NEXT_PUBLIC_API_URL=https://art.playukraine.com
+# REACT_APP_API_URL=https://art.playukraine.com
+# NEXT_PUBLIC_PROD_API_URL=https://art.playukraine.com/api/
+
+# Google Analytics
+# NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+# Database configuration
+DATABASE_URL=postgres://user:password@localhost:5432/dbname
+
+# Redis cache
+REDIS_URL=redis://localhost:6379
+# Or for Upstash
+# UPSTASH_REDIS_REST_URL=
+# UPSTASH_REDIS_REST_TOKEN=
+
+# Shopify credentials
+SHOPIFY_API_KEY=
+SHOPIFY_API_SECRET=
+
+# NextAuth configuration
+NEXTAUTH_SECRET=
+GITHUB_ID=
+GITHUB_SECRET=

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the project directory to ensure the correct version.
 
 ## Getting Started
 
-This project requires Node 18 or later. Install dependencies and create a local `.env` file based on `.env.sample`:
+This project requires Node 18 or later. Install dependencies and create a local `.env` file based on `.env.example`:
 
 ```bash
 npm install
@@ -24,13 +24,14 @@ Tests rely on an up-to-date `package-lock.json`.
 
 ## Environment Variables
 
-Copy `.env.sample` to `.env` and update the values as needed.
+Copy `.env.example` to `.env` and update the values as needed.
 
 - `DATABASE_URL` – connection string for PostgreSQL
 - `REDIS_URL` or `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN`
 - `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET`
 - `NEXTAUTH_SECRET` and provider credentials like `GITHUB_ID`/`GITHUB_SECRET`
 - `NEXT_PUBLIC_HOST` – hostname used when rendering on the server
+- `API_BASE_URL` - base URL for server-side API requests
 
 ## NextAuth
 


### PR DESCRIPTION
## Summary
- update `.env.example` with latest variables and new `API_BASE_URL`
- update README instructions to use `.env.example` and document `API_BASE_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845186976208323b1ccd885fe0d6480