### PR TITLE
Use getBaseUrl in axios config

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,21 +1,18 @@
 // src/utils/api.js
 
 import axios from 'axios'
-// Determine the host in both browser and server environments
-const host =
-  typeof window !== 'undefined'
-    ? window.location.hostname
-    : process.env.NEXT_PUBLIC_HOST || 'localhost'
-const isLocalhost = host === 'localhost' || host === '127.0.0.1'
+import { getBaseUrl } from './getBaseUrl'
+
+// Resolve the base URL using getBaseUrl with a fallback to API_BASE_URL
+const resolvedBaseUrl = getBaseUrl() || process.env.API_BASE_URL || ''
+
 // Create an instance of axios with default configurations
 const API = axios.create({
-        baseURL: isLocalhost
-                ? `${(process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000')}/api/`
-                : process.env.NEXT_PUBLIC_PROD_API_URL || 'https://art.playukraine.com/api/',
-	timeout: 10000, // Optional: set a timeout for requests
-	headers: {
-		'Content-Type': 'application/json',
-	},
+        baseURL: `${resolvedBaseUrl.replace(/\/$/, '')}/api/`,
+        timeout: 10000, // Optional: set a timeout for requests
+        headers: {
+                'Content-Type': 'application/json',
+        },
 })
 
 // Add a request interceptor to include the token in headers


### PR DESCRIPTION
## Summary
- import `getBaseUrl` in `src/utils/api.js`
- use `getBaseUrl()` when creating the Axios base URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68451865490883238614583dcafc2319