### PR TITLE
Add Cloud Run deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ npm run build
 npm start
 ```
 
+## Deployment
+
+See [docs/GCP_DEPLOY.md](docs/GCP_DEPLOY.md) for instructions on building a Docker image and deploying to Google Cloud Run.
+
+
 
 ## Testing
 

--- a/docs/GCP_DEPLOY.md
+++ b/docs/GCP_DEPLOY.md
@@ -1,0 +1,32 @@
+# Deploying to Google Cloud Run
+
+This guide shows how to build the Next.js application into a Docker image, store it in Google Artifact Registry and deploy the container to Cloud Run.
+
+1. Install the [gcloud CLI](https://cloud.google.com/sdk/docs/install) and authenticate:
+   ```bash
+   gcloud auth login
+   gcloud config set project <PROJECT_ID>
+   gcloud auth configure-docker <REGION>-docker.pkg.dev
+   ```
+2. Build the production files:
+   ```bash
+   npm run build
+   ```
+3. Build a Docker image and tag it for Artifact Registry:
+   ```bash
+   docker build -t <REGION>-docker.pkg.dev/<PROJECT_ID>/art-culture/app:latest .
+   ```
+4. Push the image to Artifact Registry:
+   ```bash
+   docker push <REGION>-docker.pkg.dev/<PROJECT_ID>/art-culture/app:latest
+   ```
+5. Deploy the container to Cloud Run:
+   ```bash
+   gcloud run deploy art-culture \
+     --image <REGION>-docker.pkg.dev/<PROJECT_ID>/art-culture/app:latest \
+     --region <REGION> \
+     --platform managed \
+     --allow-unauthenticated
+   ```
+
+Replace `<PROJECT_ID>` with your Google Cloud project identifier and `<REGION>` with the desired region (for example `us-central1`).


### PR DESCRIPTION
## Summary
- document how to containerize and deploy the app to Google Cloud Run
- link the new deployment doc from the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845186785548323b1435666301b9e0a