### PR TITLE
Add GCP Cloud Run deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm start
 
 ## Deployment
 
-See [docs/GCP_DEPLOY.md](docs/GCP_DEPLOY.md) for instructions on building a Docker image and deploying to Google Cloud Run.
+See [docs/GCP_DEPLOYMENT.md](docs/GCP_DEPLOYMENT.md) for instructions on building a Docker image and deploying to Google Cloud Run.
 
 
 

--- a/docs/GCP_DEPLOYMENT.md
+++ b/docs/GCP_DEPLOYMENT.md
@@ -1,0 +1,32 @@
+# Deploying on Google Cloud Platform
+
+This guide explains how to build and deploy the Next.js application using **Google Cloud Run**. You will store the Docker image in **Google Container Registry**.
+
+1. Install the [gcloud CLI](https://cloud.google.com/sdk/docs/install) and authenticate:
+   ```bash
+   gcloud auth login
+   gcloud config set project <PROJECT_ID>
+   gcloud auth configure-docker
+   ```
+2. Build the production files:
+   ```bash
+   npm run build
+   ```
+3. Build a Docker image and tag it for Container Registry:
+   ```bash
+   docker build -t gcr.io/<PROJECT_ID>/art-culture:latest .
+   ```
+4. Push the image to Container Registry:
+   ```bash
+   docker push gcr.io/<PROJECT_ID>/art-culture:latest
+   ```
+5. Deploy the container to Cloud Run:
+   ```bash
+   gcloud run deploy art-culture \
+     --image gcr.io/<PROJECT_ID>/art-culture:latest \
+     --platform managed \
+     --region <REGION> \
+     --allow-unauthenticated
+   ```
+
+Replace `<PROJECT_ID>` with your Google Cloud project identifier and `<REGION>` with the region where you want the service to run.


### PR DESCRIPTION
## Summary
- document how to deploy on Google Cloud Platform via Container Registry and Cloud Run
- link to new deployment guide in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68451baed8f88323985e00d3e4f6e438