### PR TITLE
Add Docker section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ npm start
 
 See [docs/GCP_DEPLOY.md](docs/GCP_DEPLOY.md) for instructions on building a Docker image and deploying to Google Cloud Run.
 
+### Docker
+
+Build a production image using the included `Dockerfile`:
+
+```bash
+docker build -t art-culture .
+```
+
+Run the container locally with environment variables from your `.env` file:
+
+```bash
+docker run --env-file .env -p 3000:3000 art-culture
+```
+
+The image can also be pushed to a container registry for deployment. See the [GCP deployment guide](docs/GCP_DEPLOY.md) for an example using Google Artifact Registry and Cloud Run.
+
 
 
 ## Testing


### PR DESCRIPTION
## Summary
- document docker build and run in README
- note that the image can be pushed to a registry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68451bb7bad08323b60e84c643c7bee1