### PR TITLE
Fix base URL for news fetching

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,9 @@ const config = {
       },
     ],
   },
+  env: {
+    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  },
 };
 
 export default config;

--- a/src/app/news/[id]/page.tsx
+++ b/src/app/news/[id]/page.tsx
@@ -12,14 +12,20 @@ interface Props {
 }
 
 export async function generateStaticParams() {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+  const baseUrl =
+    process.env.NODE_ENV === 'production'
+      ? process.env.NEXT_PUBLIC_API_BASE_URL
+      : 'http://localhost:3000'
   const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
   return newsList.map((n) => ({ id: n.id }))
 }
 
 export async function generateMetadata({ params }: Props) {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+  const baseUrl =
+    process.env.NODE_ENV === 'production'
+      ? process.env.NEXT_PUBLIC_API_BASE_URL
+      : 'http://localhost:3000'
   const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
   const news = newsList.find((n) => n.id === params.id)
@@ -39,7 +45,10 @@ export async function generateMetadata({ params }: Props) {
 }
 
 export default async function NewsPage({ params }: Props) {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+  const baseUrl =
+    process.env.NODE_ENV === 'production'
+      ? process.env.NEXT_PUBLIC_API_BASE_URL
+      : 'http://localhost:3000'
   const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
   const news = newsList.find((n) => n.id === params.id) as NewsItem

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -2,7 +2,10 @@ import Link from 'next/link'
 import { NewsItem } from '@/data/news'
 
 export default async function NewsIndex() {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL || ''
+  const baseUrl =
+    process.env.NODE_ENV === 'production'
+      ? process.env.NEXT_PUBLIC_API_BASE_URL
+      : 'http://localhost:3000'
   const res = await fetch(`${baseUrl}/api/news`)
   const newsList: NewsItem[] = await res.json()
 


### PR DESCRIPTION
## Summary
- export `NEXT_PUBLIC_API_BASE_URL` from `next.config.js`
- fetch news with proper base URL in `/news` pages

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452347d6508323b1878386a26ae0cf