### PR TITLE
Add NEXT_PUBLIC_API_BASE_URL variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 # Example environment variables for Art & Culture
 # Base URL used by fetch() in server components
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
 API_BASE_URL=http://localhost:5000
 NEXT_PUBLIC_API_URL=http://localhost:5000
 REACT_APP_API_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ Copy `.env.sample` to `.env` and update the values as needed.
 - `SHOPIFY_API_KEY` and `SHOPIFY_API_SECRET`
 - `NEXTAUTH_SECRET` and provider credentials like `GITHUB_ID`/`GITHUB_SECRET`
 - `NEXT_PUBLIC_HOST` – hostname used when rendering on the server
-- `API_BASE_URL` - base URL for server-side API requests
+- `NEXT_PUBLIC_API_BASE_URL` – base URL used by server components to fetch internal API routes
+- `API_BASE_URL` - fallback base URL for server-side API utilities
 - `TOKEN` - access token for internal APIs
+- `NEXT_PUBLIC_API_URL` is no longer used and can be removed
 
 ## NextAuth
 


### PR DESCRIPTION
## Summary
- document `NEXT_PUBLIC_API_BASE_URL` in `.env.sample`
- mention the new variable in README and clarify `NEXT_PUBLIC_API_URL` is unused

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684525fa25c883239b71bdd063283a4c