### PR TITLE
Fix type declaration for css-calc

### DIFF
--- a/src/types/@csstools__css-calc.d.ts
+++ b/src/types/@csstools__css-calc.d.ts
@@ -1,0 +1,1 @@
+declare module '@csstools/css-calc';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext", // ES-модулі
-    "moduleResolution": "node", // Vite/Next.js чекають moduleResolution=node
+    "moduleResolution": "node16", // Новий алгоритм резолвінгу модулів
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,


### PR DESCRIPTION
## Summary
- use node16 module resolution for TS
- add a fallback declaration for `@csstools/css-calc`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a63620b08323a1701c98e09dda04