### PR TITLE
fix(server): make eslint.config compatible with ESM or CJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Portions of the backend are gradually being migrated to **TypeScript** for impro
 
 ## Tests and Linting
 
-Dev dependencies such as Jest and ESLint are installed with `npm install` in the `server` directory. ESLint now uses the flat configuration file `eslint.config.js` at the project root. Tests live under `server/tests` and must be executed from that folder.
+Dev dependencies such as Jest and ESLint are installed with `npm install` in the `server` directory. ESLint now uses the flat configuration file `eslint.config.cjs` at the project root. Tests live under `server/tests` and must be executed from that folder.
 
 ```bash
 npm run lint --prefix server

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -16,6 +16,18 @@ module.exports = [
       parser: tsParser,
       ecmaVersion: 2023,
       sourceType: 'module',
+      globals: {
+        ...js.environments.node.globals,
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        jest: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+      },
     },
     plugins: {
       '@typescript-eslint': tsPlugin,

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,9 +1,9 @@
-import js from '@eslint/js'
-import tsPlugin from '@typescript-eslint/eslint-plugin'
-import tsParser from '@typescript-eslint/parser'
-import importPlugin from 'eslint-plugin-import'
+const js = require('@eslint/js')
+const tsPlugin = require('@typescript-eslint/eslint-plugin')
+const tsParser = require('@typescript-eslint/parser')
+const importPlugin = require('eslint-plugin-import')
 
-export default [
+module.exports = [
   js.configs.recommended,
   {
     files: ['**/*.{js,ts}'],

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,11 +1,13 @@
 const { createRequire } = require('module')
 const path = require('path')
+
 const requireServer = createRequire(path.join(__dirname, 'server', 'package.json'))
 
 const js = requireServer('@eslint/js')
 const tsPlugin = requireServer('@typescript-eslint/eslint-plugin')
 const tsParser = requireServer('@typescript-eslint/parser')
 const importPlugin = requireServer('eslint-plugin-import')
+const globals = requireServer('globals')
 
 module.exports = [
   js.configs.recommended,
@@ -17,16 +19,8 @@ module.exports = [
       ecmaVersion: 2023,
       sourceType: 'module',
       globals: {
-        ...js.environments.node.globals,
-        describe: 'readonly',
-        it: 'readonly',
-        test: 'readonly',
-        expect: 'readonly',
-        jest: 'readonly',
-        beforeAll: 'readonly',
-        afterAll: 'readonly',
-        beforeEach: 'readonly',
-        afterEach: 'readonly',
+        ...globals.node,
+        ...globals.jest,
       },
     },
     plugins: {

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,7 +1,11 @@
-const js = require('@eslint/js')
-const tsPlugin = require('@typescript-eslint/eslint-plugin')
-const tsParser = require('@typescript-eslint/parser')
-const importPlugin = require('eslint-plugin-import')
+const { createRequire } = require('module')
+const path = require('path')
+const requireServer = createRequire(path.join(__dirname, 'server', 'package.json'))
+
+const js = requireServer('@eslint/js')
+const tsPlugin = requireServer('@typescript-eslint/eslint-plugin')
+const tsParser = requireServer('@typescript-eslint/parser')
+const importPlugin = requireServer('eslint-plugin-import')
 
 module.exports = [
   js.configs.recommended,


### PR DESCRIPTION
## Summary
- rename the flat ESLint config to `eslint.config.cjs`
- switch to `require` syntax for CommonJS
- update README to point to `eslint.config.cjs`

## Testing
- `npm run lint --prefix server` *(fails: Cannot find module '@eslint/js')*
- `npm test --prefix server` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642096d2d08323b216f4f0ae7bb515