### PR TITLE
Fix post controller exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Завдання Codex
+
+**Мета:** Вирівняти імена експорту/імпорту в postController.ts та postRoutes.ts, щоб тести на `/api/posts` пройшли успішно.
+
+**Що потрібно зробити:**
+1. У `postController.ts` експортувати всі функції з одниною в кінці:
+   - `getCreatorsPosts`
+   - `getAuthorsPosts`
+   - `getExhibitionsPost`
+   - `getMuseumsPost`
+   - `getPostsByAuthorId`
+   - `getPostByExhibitionId`
+   - `getPostByMuseumId`
+2. У `postRoutes.ts` імпортувати саме ці назви.
+3. Перевірити маршрути:
+   ```ts
+   router.get('/creators', getCreatorsPosts);
+   router.get('/authors',  getAuthorsPosts);
+   router.get('/exhibitions', getExhibitionsPost);
+   router.get('/museums', getMuseumsPost);
+
+   router.get('/by-author/:authorId',      getPostsByAuthorId);
+   router.get('/by-exhibition/:exhibitionId', getPostByExhibitionId);
+   router.get('/by-museum/:museumId',       getPostByMuseumId);
+   ```
+
+Запустити `npm run dev` та `npm test` і гарантувати, що сервер стартує без помилок та тест `posts.test.js` повертає 200 та порожній масив.

--- a/server/src/controllers/postController.ts
+++ b/server/src/controllers/postController.ts
@@ -241,6 +241,36 @@ export function makeRoleFinder(role: 'CREATOR' | 'AUTHOR' | 'EXHIBITION' | 'MUSE
 
 export const getCreatorsPosts = makeRoleFinder("CREATOR");
 export const getAuthorsPosts = makeRoleFinder("AUTHOR");
-export const getExhibitionsPosts = makeRoleFinder("EXHIBITION");
-export const getMuseumsPosts = makeRoleFinder("MUSEUM");
+export const getExhibitionsPost = makeRoleFinder("EXHIBITION");
+export const getMuseumsPost = makeRoleFinder("MUSEUM");
+
+// ———————————————
+// GET POSTS BY ENTITY ID
+// ———————————————
+export function makeByAuthorId(param: "authorId" | "exhibitionId" | "museumId") {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = parseInt(req.params[param], 10);
+      if (isNaN(id)) {
+        res.status(400).json({ error: "Invalid ID" });
+        return;
+      }
+      const posts = await prisma.post.findMany({
+        where: { [param]: id } as any,
+        include: { author: { select: { id: true, email: true, title: true, role: true } } },
+        orderBy: { createdAt: "desc" },
+      });
+      res.json({ posts });
+    } catch (err: any) {
+      if (err.code === "P2021") {
+        return res.json({ posts: [] });
+      }
+      next(err);
+    }
+  };
+}
+
+export const getPostsByAuthorId = makeByAuthorId("authorId");
+export const getPostByExhibitionId = makeByAuthorId("exhibitionId");
+export const getPostByMuseumId = makeByAuthorId("museumId");
 

--- a/server/src/routes/postRoutes.ts
+++ b/server/src/routes/postRoutes.ts
@@ -8,8 +8,8 @@ import {
   updatePost,
   getCreatorsPosts,
   getAuthorsPosts,
-  getExhibitionsPosts,
-  getMuseumsPosts,
+  getExhibitionsPost,
+  getMuseumsPost,
   getPostsByAuthorId,
   getPostByExhibitionId,
   getPostByMuseumId,
@@ -37,8 +37,8 @@ router.delete('/:id', authenticateToken, deletePost);
 // GET POSTS BY ROLE
 router.get('/creators', getCreatorsPosts);
 router.get('/authors', getAuthorsPosts);
-router.get('/exhibitions', getExhibitionsPosts);
-router.get('/museums', getMuseumsPosts);
+router.get('/exhibitions', getExhibitionsPost);
+router.get('/museums', getMuseumsPost);
 
 // GET POSTS BY ENTITY ID
 router.get('/by-author/:authorId', getPostsByAuthorId);


### PR DESCRIPTION
## Summary
- add repo-wide instructions about aligning post exports
- export new helper `makeByAuthorId` and related handlers
- rename role-based post handlers
- update post routes to use the renamed handlers

## Testing
- `npm run dev --prefix server` *(fails: nodemon not found)*
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af6a1838483239b3330a4455b3111