### PR TITLE
Fix post routes naming and adjust tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "dev": "nodemon --watch src --ext ts --exec \"TS_NODE_TRANSPILE_ONLY=1 node --experimental-specifier-resolution=node --loader ts-node/esm src/index.ts\"",
+    "dev": "ts-node --esm src/index.ts",
+    "dev:watch": "nodemon --watch src --ext ts --exec \"npm run dev\"",
     "prisma": "prisma",
     "lint": "eslint src --ext .js,.ts,.jsx,.tsx,.cjs,.mjs",
     "format": "prettier --write .",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -3,9 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider          = "postgresql"
-  url               = env("DATABASE_URL")
-  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 enum Role {

--- a/server/src/controllers/postController.ts
+++ b/server/src/controllers/postController.ts
@@ -244,8 +244,8 @@ export function makeRoleFinder(role: 'CREATOR' | 'AUTHOR' | 'EXHIBITION' | 'MUSE
 
 export const getCreatorsPosts = makeRoleFinder("CREATOR");
 export const getAuthorsPosts = makeRoleFinder("AUTHOR");
-export const getExhibitionsPosts = makeRoleFinder("EXHIBITION");
-export const getMuseumsPosts = makeRoleFinder("MUSEUM");
+export const getExhibitionsPost = makeRoleFinder("EXHIBITION");
+export const getMuseumsPost = makeRoleFinder("MUSEUM");
 
 // ———————————————
 // GET POSTS BY ENTITY ID
@@ -274,6 +274,6 @@ export function makeByAuthorId(param: "authorId" | "exhibitionId" | "museumId") 
 }
 
 export const getPostsByAuthorId = makeByAuthorId("authorId");
-export const getPostsByExhibitionId = makeByAuthorId("exhibitionId");
-export const getPostsByMuseumId = makeByAuthorId("museumId");
+export const getPostByExhibitionId = makeByAuthorId("exhibitionId");
+export const getPostByMuseumId = makeByAuthorId("museumId");
 

--- a/server/src/routes/postRoutes.ts
+++ b/server/src/routes/postRoutes.ts
@@ -8,11 +8,11 @@ import {
   updatePost,
   getCreatorsPosts,
   getAuthorsPosts,
-  getExhibitionsPosts,
-  getMuseumsPosts,
+  getExhibitionsPost,
+  getMuseumsPost,
   getPostsByAuthorId,
-  getPostsByExhibitionId,
-  getPostsByMuseumId,
+  getPostByExhibitionId,
+  getPostByMuseumId,
   upload,
 } from '../controllers/postController.js';
 import authenticateToken from '../middleware/authMiddleware.js';
@@ -37,12 +37,12 @@ router.delete('/:id', authenticateToken, deletePost);
 // GET POSTS BY ROLE
 router.get('/creators', getCreatorsPosts);
 router.get('/authors', getAuthorsPosts);
-router.get('/exhibitions', getExhibitionsPosts);
-router.get('/museums', getMuseumsPosts);
+router.get('/exhibitions', getExhibitionsPost);
+router.get('/museums', getMuseumsPost);
 
 // GET POSTS BY ENTITY ID
 router.get('/by-author/:authorId', getPostsByAuthorId);
-router.get('/by-exhibition/:exhibitionId', getPostsByExhibitionId);
-router.get('/by-museum/:museumId', getPostsByMuseumId);
+router.get('/by-exhibition/:exhibitionId', getPostByExhibitionId);
+router.get('/by-museum/:museumId', getPostByMuseumId);
 
 export default router;

--- a/server/src/tests/posts.test.ts
+++ b/server/src/tests/posts.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import request from 'supertest'
+import { jest } from '@jest/globals'
 import app from '../app.js'
 import prisma from '../prismaClient.js'
 


### PR DESCRIPTION
## Summary
- standardize post controller export names
- sync route imports with controller exports
- rename posts test to TypeScript and fix jest mock imports
- remove shadow DB from Prisma schema
- update dev scripts to use ts-node

## Testing
- `npm install` *(fails: ENOTFOUND registry.npmjs.org)*
- `npm run dev` *(fails: ts-node not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b084a0b608323aceb8d2412d09f3e