### PR TITLE
Fix ts-node loader config

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "dev": "ts-node --esm src/index.ts",
+    "dev": "node --loader ts-node/esm src/index.ts",
     "dev:watch": "nodemon --watch src --ext ts --exec \"npm run dev\"",
     "prisma": "prisma",
     "lint": "eslint src --ext .js,.ts,.jsx,.tsx,.cjs,.mjs",


### PR DESCRIPTION
## Summary
- use `node --loader ts-node/esm` for dev server

## Testing
- `npm run dev` *(fails: Cannot find module 'ts-node/esm')*
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_686b0b37e4c883238ddebd1c9d503a86