### PR TITLE
Fix Jest config for ESM TypeScript

### DIFF
--- a/server/jest.config.cjs
+++ b/server/jest.config.cjs
@@ -1,10 +1,12 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   transform: {
-    // Для всіх .ts/.tsx файлів використовуємо ts-jest і примусово в CommonJS
-    '^.+\\.[tj]sx?$': ['ts-jest', { useESM: false }]
+    '^.+\\.[tj]sx?$': ['ts-jest', {
+      tsconfig: 'server/tsconfig.json',
+      useESM: true
+    }]
   },
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   testMatch: ['**/src/tests/**/*.test.ts'],
@@ -12,6 +14,6 @@ module.exports = {
     // Якщо тест або код імпортує без розширення .js
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
-  // Щоб Jest не чекав ESM-модулі
-  extensionsToTreatAsEsm: [],
+  // Дати Jest знати, що .ts — це ESM
+  extensionsToTreatAsEsm: ['.ts'],
 };

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,11 @@
     "node": ">=20.0.0"
   },
   "type": "module",
+  "jest": {
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ]
+  },
   "main": "index.js",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary
- enable ESM preset for ts-jest
- mark TS files as ESM for Jest
- add Jest ESM mapping in package.json

## Testing
- `npm ci` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npx jest --config jest.config.cjs --coverage` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6871ca6750e483239539685055f2e948