### PR TITLE
Fix .gitignore for yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ node_modules/
 server/uploads/
 jest.config.js
 server/coverage/
+
+yarn.lock


### PR DESCRIPTION
## Summary
- add `yarn.lock` to the repo `.gitignore`

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npx jest --coverage` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687241e56b648323a35bae3c75e02ee9