### PR TITLE
Fix babel config loading in server tests

### DIFF
--- a/server/analysis/babel-config-fix.md
+++ b/server/analysis/babel-config-fix.md
@@ -1,0 +1,15 @@
+# Babel Config Fix
+
+## Problem
+`babel.config.js` was loaded as an ES module because `type: module` is set in `package.json`. Jest with `babel-jest` tried to import it, but the file used CommonJS `module.exports`, causing `module is not defined` errors.
+
+## Changes
+- Renamed `babel.config.js` to `babel.config.cjs`.
+- Removed the `preset` property from the Jest configuration so only `babel-jest` handles TypeScript files.
+
+## Verification
+Run inside `server/`:
+```bash
+npm ci
+npx jest --coverage
+```

--- a/server/analysis/fix-babel-config.patch
+++ b/server/analysis/fix-babel-config.patch
@@ -1,0 +1,64 @@
+commit e473658c2821c2b209a5b01b3832d2867bb7fc93
+Author: Codex <codex@openai.com>
+Date:   Sat Jul 12 12:12:49 2025 +0000
+    chore: rename babel config and update jest
+diff --git a/server/babel.config.js b/server/babel.config.cjs
+similarity index 70%
+rename from server/babel.config.js
+rename to server/babel.config.cjs
+index aa2a20e..ca63f78 100644
+--- a/server/babel.config.js
++++ b/server/babel.config.cjs
+@@ -1,3 +1,4 @@
++/** @type {import('@babel/core').TransformOptions} */
+ module.exports = {
+   presets: [
+     ['@babel/preset-env', { targets: { node: '20' } }],
+diff --git a/server/package.json b/server/package.json
+index 522b6ac..c7f3e7b 100644
+--- a/server/package.json
++++ b/server/package.json
+@@ -6,21 +6,36 @@
+   },
+   "type": "module",
+   "jest": {
+-    "roots": ["<rootDir>/src"],
+-    "testMatch": ["**/src/tests/**/*.test.ts"],
++    "roots": [
++      "<rootDir>/src"
++    ],
++    "testMatch": [
++      "**/src/tests/**/*.test.ts"
++    ],
+     "transform": {
+       "^.+\\.[tj]sx?$": "babel-jest"
+     },
+     "transformIgnorePatterns": [],
+-    "preset": "ts-jest/presets/default-esm",
+     "testEnvironment": "node",
+-    "extensionsToTreatAsEsm": [".ts"],
++    "extensionsToTreatAsEsm": [
++      ".ts"
++    ],
+     "moduleNameMapper": {
+       "^(\\.{1,2}/.*)\\.js$": "$1"
+     },
+-    "moduleFileExtensions": ["ts","js","json","node"],
+-    "testPathIgnorePatterns": ["/node_modules/","/dist/"],
+-    "modulePathIgnorePatterns": ["<rootDir>/dist/"]
++    "moduleFileExtensions": [
++      "ts",
++      "js",
++      "json",
++      "node"
++    ],
++    "testPathIgnorePatterns": [
++      "/node_modules/",
++      "/dist/"
++    ],
++    "modulePathIgnorePatterns": [
++      "<rootDir>/dist/"
++    ]
+   },
+   "main": "index.js",
+   "license": "MIT",

--- a/server/babel.config.cjs
+++ b/server/babel.config.cjs
@@ -1,3 +1,4 @@
+/** @type {import('@babel/core').TransformOptions} */
 module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: '20' } }],

--- a/server/package.json
+++ b/server/package.json
@@ -6,21 +6,36 @@
   },
   "type": "module",
   "jest": {
-    "roots": ["<rootDir>/src"],
-    "testMatch": ["**/src/tests/**/*.test.ts"],
+    "roots": [
+      "<rootDir>/src"
+    ],
+    "testMatch": [
+      "**/src/tests/**/*.test.ts"
+    ],
     "transform": {
       "^.+\\.[tj]sx?$": "babel-jest"
     },
     "transformIgnorePatterns": [],
-    "preset": "ts-jest/presets/default-esm",
     "testEnvironment": "node",
-    "extensionsToTreatAsEsm": [".ts"],
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1"
     },
-    "moduleFileExtensions": ["ts","js","json","node"],
-    "testPathIgnorePatterns": ["/node_modules/","/dist/"],
-    "modulePathIgnorePatterns": ["<rootDir>/dist/"]
+    "moduleFileExtensions": [
+      "ts",
+      "js",
+      "json",
+      "node"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/"
+    ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/dist/"
+    ]
   },
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- rename server babel config to `babel.config.cjs`
- use only `babel-jest` in server `package.json`
- document and patch the fix

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npx jest --coverage` *(fails: could not download jest)*

------
https://chatgpt.com/codex/tasks/task_e_687250835fb883239e0bd334da84a9eb