### PR TITLE
Fix Jest import.meta config

### DIFF
--- a/server/analysis/fix-jest-import-meta.patch
+++ b/server/analysis/fix-jest-import-meta.patch
@@ -1,0 +1,36 @@
+diff --git a/server/babel.config.cjs b/server/babel.config.cjs
+index 11b1128..820a80a 100644
+--- a/server/babel.config.cjs
++++ b/server/babel.config.cjs
+@@ -4,5 +4,8 @@ module.exports = {
+   presets: [
+     ['@babel/preset-env', { targets: { node: '20' } }],
+     '@babel/preset-typescript'
++  ],
++  plugins: [
++    '@babel/plugin-syntax-import-meta'
+   ]
+ };
+diff --git a/server/package.json b/server/package.json
+index bdcbf76..44cdf7b 100644
+--- a/server/package.json
++++ b/server/package.json
+@@ -18,7 +18,9 @@
+     "transformIgnorePatterns": [],
+     "testEnvironment": "node",
+     "extensionsToTreatAsEsm": [
+-      ".ts"
++      ".ts",
++      ".js",
++      ".cjs"
+     ],
+     "moduleNameMapper": {
+       "^(\\.{1,2}/.*)\\.js$": "$1"
+@@ -70,6 +72,7 @@
+     "@babel/core": "^7.24.0",
+     "@babel/preset-env": "^7.24.0",
+     "@babel/preset-typescript": "^7.24.0",
++    "@babel/plugin-syntax-import-meta": "^7.24.0",
+     "babel-jest": "^29.7.0",
+     "@eslint/js": "^9.30.1",
+     "@eslint/json": "^0.12.0",

--- a/server/analysis/import-meta-fix.md
+++ b/server/analysis/import-meta-fix.md
@@ -1,0 +1,10 @@
+# Fix import.meta in Jest
+
+Jest failed to parse TypeScript files that use `import.meta` because `babel-jest` lacked the plugin and ESM settings. The solution adds `@babel/plugin-syntax-import-meta` to Babel and updates Jest configuration to treat `.ts`, `.js`, and `.cjs` as ESM.
+
+## Verification
+```bash
+cd server
+npm install
+npx jest --coverage
+```

--- a/server/babel.config.cjs
+++ b/server/babel.config.cjs
@@ -4,5 +4,8 @@ module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: '20' } }],
     '@babel/preset-typescript'
+  ],
+  plugins: [
+    '@babel/plugin-syntax-import-meta'
   ]
 };

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,9 @@
     "transformIgnorePatterns": [],
     "testEnvironment": "node",
     "extensionsToTreatAsEsm": [
-      ".ts"
+      ".ts",
+      ".js",
+      ".cjs"
     ],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1"
@@ -70,6 +72,7 @@
     "@babel/core": "^7.24.0",
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-typescript": "^7.24.0",
+    "@babel/plugin-syntax-import-meta": "^7.24.0",
     "babel-jest": "^29.7.0",
     "@eslint/js": "^9.30.1",
     "@eslint/json": "^0.12.0",


### PR DESCRIPTION
## Summary
- add `@babel/plugin-syntax-import-meta` plugin
- support `.ts`, `.js`, `.cjs` extensions as ESM in Jest
- document the fix and provide patch file for reference

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx jest --coverage` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687282ffa230832381b1779ae824b4aa