### PR TITLE
Add Jest+Babel audit and patches

### DIFF
--- a/server/analysis/jest-babel-audit.md
+++ b/server/analysis/jest-babel-audit.md
@@ -1,0 +1,48 @@
+# Jest + Babel Audit
+
+## Project Overview
+- **Node**: `v20.19.3`
+- **npm**: `11.4.2`
+- **Jest**: `^29.7.0`
+- **babel-jest**: `^29.7.0`
+- **@babel/core**: `^7.24.0`
+
+The project stores Jest configuration inside `package.json` and uses a separate `babel.config.cjs`.
+
+## Current Configuration
+- `babel.config.cjs` uses `@babel/preset-env`, `@babel/preset-typescript` and the `@babel/plugin-syntax-import-meta` plugin.
+- Jest transforms all `.ts` and `.js` files using `babel-jest`.
+- `extensionsToTreatAsEsm` included `.ts`, `.js`, and `.cjs`.
+
+## Observed Errors
+- `npm install` fails with a `403 Forbidden` error when requesting `@babel/plugin-syntax-import-meta@^7.24.0`.
+- `npx jest --coverage` fails before tests run because Jest cannot be fetched.
+
+```
+npm ERR! 403 403 Forbidden - GET https://registry.npmjs.org/@babel%2fplugin-syntax-import-meta
+```
+
+```
+npm ERR! 403 403 Forbidden - GET https://registry.npmjs.org/jest
+```
+
+These errors were captured during the audit.
+
+## Findings
+- The lock file lists `@babel/plugin-syntax-import-meta@7.10.4`, but `package.json` requires `^7.24.0`, a non‑existent version. This causes `npm install` to fail.
+- Including `.js` and `.cjs` under `extensionsToTreatAsEsm` is unnecessary for TypeScript tests and complicates module resolution.
+- `babel.config.cjs` lacked `root: true`/`babelrc: false` to ensure Jest loads only this config.
+
+## Recommendations
+1. Pin `@babel/plugin-syntax-import-meta` to the published `7.10.4` version.
+2. Limit Jest's `extensionsToTreatAsEsm` to `['.ts']`.
+3. Explicitly set `root: true` and `babelrc: false` in `babel.config.cjs`.
+4. Reinstall modules and run tests:
+   ```bash
+   rm -rf node_modules package-lock.json
+   npm install
+   npx jest --coverage
+   ```
+
+## Patch Summary
+Patch files in `analysis/patches/` implement these changes for quick application.

--- a/server/analysis/patches/babel-config.patch
+++ b/server/analysis/patches/babel-config.patch
@@ -1,0 +1,13 @@
+diff --git a/server/babel.config.cjs b/server/babel.config.cjs
+index 820a80a..1bbd758 100644
+--- a/server/babel.config.cjs
++++ b/server/babel.config.cjs
+@@ -1,6 +1,7 @@
+ /** @type {import('@babel/core').TransformOptions} */
+ module.exports = {
+-
++  root: true,
++  babelrc: false,
+   presets: [
+     ['@babel/preset-env', { targets: { node: '20' } }],
+     '@babel/preset-typescript'

--- a/server/analysis/patches/package-json.patch
+++ b/server/analysis/patches/package-json.patch
@@ -1,0 +1,24 @@
+diff --git a/server/package.json b/server/package.json
+index 44cdf7b..04a79d5 100644
+--- a/server/package.json
++++ b/server/package.json
+@@ -18,9 +18,7 @@
+     "transformIgnorePatterns": [],
+     "testEnvironment": "node",
+     "extensionsToTreatAsEsm": [
+-      ".ts",
+-      ".js",
+-      ".cjs"
++      ".ts"
+     ],
+     "moduleNameMapper": {
+       "^(\\.{1,2}/.*)\\.js$": "$1"
+@@ -72,7 +70,7 @@
+     "@babel/core": "^7.24.0",
+     "@babel/preset-env": "^7.24.0",
+     "@babel/preset-typescript": "^7.24.0",
+-    "@babel/plugin-syntax-import-meta": "^7.24.0",
++    "@babel/plugin-syntax-import-meta": "^7.10.4",
+     "babel-jest": "^29.7.0",
+     "@eslint/js": "^9.30.1",
+     "@eslint/json": "^0.12.0",

--- a/server/babel.config.cjs
+++ b/server/babel.config.cjs
@@ -1,6 +1,7 @@
 /** @type {import('@babel/core').TransformOptions} */
 module.exports = {
-
+  root: true,
+  babelrc: false,
   presets: [
     ['@babel/preset-env', { targets: { node: '20' } }],
     '@babel/preset-typescript'

--- a/server/package.json
+++ b/server/package.json
@@ -18,9 +18,7 @@
     "transformIgnorePatterns": [],
     "testEnvironment": "node",
     "extensionsToTreatAsEsm": [
-      ".ts",
-      ".js",
-      ".cjs"
+      ".ts"
     ],
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1"
@@ -72,7 +70,7 @@
     "@babel/core": "^7.24.0",
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-typescript": "^7.24.0",
-    "@babel/plugin-syntax-import-meta": "^7.24.0",
+    "@babel/plugin-syntax-import-meta": "^7.10.4",
     "babel-jest": "^29.7.0",
     "@eslint/js": "^9.30.1",
     "@eslint/json": "^0.12.0",


### PR DESCRIPTION
## Summary
- audit server Jest+Babel setup
- patch babel config for root options
- pin import-meta plugin version and refine Jest ESM settings

## Testing
- `npm run dev` *(fails: nodemon not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728cca96488323a25eee5ec0c633f2