### PR TITLE
Add manual migration for exhibition columns

### DIFF
--- a/server/prisma/migrations/manual/01_add_exhibition_columns.sql
+++ b/server/prisma/migrations/manual/01_add_exhibition_columns.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `exhibitions`
+  ADD COLUMN `created_by_id` INT NOT NULL,
+  ADD COLUMN `museum_id`       INT NULL;
+ALTER TABLE `exhibitions`
+  ADD CONSTRAINT `fk_exh_created_by`
+    FOREIGN KEY (`created_by_id`) REFERENCES `users`(`id`),
+  ADD CONSTRAINT `fk_exh_museum`
+    FOREIGN KEY (`museum_id`)     REFERENCES `users`(`id`);


### PR DESCRIPTION
## Summary
- add SQL migration file to extend the `exhibitions` table with `created_by_id` and `museum_id`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754c8cddc483239e5854aeda052ac5