### PR TITLE
Fix Jest ESM setup and route names

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -69,39 +69,21 @@
     "typescript": "^5"
   },
   "jest": {
-    "roots": [
-      "<rootDir>/src"
-    ],
     "preset": "ts-jest/presets/default-esm",
-    "testEnvironment": "node",
-    "extensionsToTreatAsEsm": [
-      ".ts"
-    ],
-    "transform": {
-      "^.+\\.(ts|tsx)$": [
-        "ts-jest",
-        {
-          "useESM": true
-        }
-      ]
+    "globals": {
+      "ts-jest": { "useESM": true }
     },
-    "moduleFileExtensions": [
-      "ts",
-      "js",
-      "json"
-    ],
-    "testMatch": [
-      "**/?(*.)+(test|spec).[tj]s?(x)"
-    ],
+    "testEnvironment": "node",
+    "roots": ["<rootDir>/src"],
+    "moduleFileExtensions": ["ts", "js", "json"],
+    "testMatch": ["**/?(*.)+(test|spec).ts"],
+    "transform": {
+      "^.+\\.ts$": ["ts-jest", { "useESM": true }]
+    },
     "moduleNameMapper": {
       "^(\\.{1,2}/.*)\\.js$": "$1"
     },
-    "transformIgnorePatterns": [
-      "/node_modules/"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/dist/"
-    ]
+    "transformIgnorePatterns": ["/node_modules/"],
+    "testPathIgnorePatterns": ["/dist/"]
   }
 }

--- a/server/src/controllers/postController.ts
+++ b/server/src/controllers/postController.ts
@@ -284,18 +284,18 @@ export function makeByParamFinder(
 // === EXPORT ROUTES ===
 export const getCreatorsPosts = makeRoleFinder("CREATOR")
 export const getAuthorsPosts = makeRoleFinder("AUTHOR")
-export const getExhibitionsPosts = makeRoleFinder("EXHIBITION")
-export const getMuseumsPosts = makeRoleFinder("MUSEUM")
+export const getExhibitionsPost = makeRoleFinder("EXHIBITION")
+export const getMuseumsPost = makeRoleFinder("MUSEUM")
 
 export const getPostsByAuthorId = makeByParamFinder(
   "authorId",
   "postsByAuthor"
 )
-export const getPostsByExhibitionId = makeByParamFinder(
+export const getPostByExhibitionId = makeByParamFinder(
   "exhibitionId",
   "postsByExhibition"
 )
-export const getPostsByMuseumId = makeByParamFinder(
+export const getPostByMuseumId = makeByParamFinder(
   "museumId",
   "postsByMuseum"
 )

--- a/server/src/routes/postRoutes.ts
+++ b/server/src/routes/postRoutes.ts
@@ -10,11 +10,11 @@ import {
   deletePost,
   getCreatorsPosts,
   getAuthorsPosts,
-  getExhibitionsPosts,
-  getMuseumsPosts,
+  getExhibitionsPost,
+  getMuseumsPost,
   getPostsByAuthorId,
-  getPostsByExhibitionId,
-  getPostsByMuseumId,
+  getPostByExhibitionId,
+  getPostByMuseumId,
 } from "../controllers/postController.js"
 import authenticateToken from "../middleware/authMiddleware.js"
 import authorize from "../middleware/roleMiddleware.js"
@@ -33,12 +33,12 @@ router.get("/authors", getAuthorsPosts)
 router.get("/author/:authorId", getPostsByAuthorId)
 
 // Фільтрація по ролі exhibition та museum
-router.get("/exhibitions", getExhibitionsPosts)
-router.get("/museums", getMuseumsPosts)
+router.get("/exhibitions", getExhibitionsPost)
+router.get("/museums", getMuseumsPost)
 
 // Фільтрація по конкретному exhibition або museum
-router.get("/exhibition/:exhibitionId", getPostsByExhibitionId)
-router.get("/museum/:museumId", getPostsByMuseumId)
+router.get("/exhibition/:exhibitionId", getPostByExhibitionId)
+router.get("/museum/:museumId", getPostByMuseumId)
 
 // ── PROTECTED POSTS ───────────────────────────────────────────────────────
 router.use(authenticateToken)

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,27 +5,14 @@
     "target": "ES2022",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "allowJs": true,
     "resolveJsonModule": true,
-    "baseUrl": "./src",
-    "paths": {
-      "@/*": [
-        "*"
-      ]
-    },
-    "typeRoots": [
-      "./node_modules/@types",
-      "./src/types"
-    ],
+    "strict": true,
     "outDir": "dist",
-    "isolatedModules": true,
-    "strict": true
+    "baseUrl": "./src",
+    "paths": { "@/*": ["*"] },
+    "typeRoots": ["./node_modules/@types", "./src/types"]
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.js", // ← додаємо JS
-    "src/types/**/*.d.ts"
-  ],
+  "include": ["src/**/*.{ts,js}", "src/types/**/*.d.ts"],
   "exclude": [
     "node_modules",
     "dist"


### PR DESCRIPTION
## Summary
- update Jest configuration in `package.json`
- tighten compiler options in `tsconfig.json`
- sync export names in `postController` and `postRoutes`

## Testing
- `npm run dev` *(fails: nodemon not found)*
- `npm test` *(fails: cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_687699c681b48323ac34ba584d877458